### PR TITLE
feat: 롤플레잉 ui 디자인 수정

### DIFF
--- a/src/features/roleplay/scenario-list/components/CreateRoleplayDialog.jsx
+++ b/src/features/roleplay/scenario-list/components/CreateRoleplayDialog.jsx
@@ -19,35 +19,60 @@ export default function CreateRoleplayDialog({
       open={open}
       onClose={onClose}
       fullWidth
-      maxWidth="xs"
+      maxWidth="sm"
       PaperProps={{
         sx: {
-          backgroundColor: '#FFFFFF',
-          borderRadius: 3,
-          border: '1px solid rgba(0,0,0,0.08)',
-          boxShadow: '0 16px 40px rgba(0,0,0,0.12)',
+          background: '#FFFFFF',
+          borderRadius: 4,
+          border: '2px solid rgba(124,108,255,0.3)',
+          boxShadow: '0 24px 64px rgba(0,0,0,0.2)',
+          overflow: 'hidden',
+          position: 'relative',
+          '&::before': {
+            content: '""',
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            height: '5px',
+            background: 'linear-gradient(90deg, #7C6CFF 0%, #4B3CF8 100%)',
+            boxShadow: '0 2px 8px rgba(124,108,255,0.4)'
+          }
+        }
+      }}
+      slotProps={{
+        backdrop: {
+          sx: {
+            backgroundColor: 'rgba(0, 0, 0, 0.7)',
+            backdropFilter: 'blur(8px)'
+          }
         }
       }}
     >
       <DialogTitle
         sx={{
           fontWeight: 700,
-          fontSize: '1.1rem',
-          color: '#111827',
-          pb: 1.5,
+          fontSize: '1.25rem',
+          color: '#212121',
+          pb: 1,
+          pt: 3.5,
+          px: 3
         }}
       >
         롤플레이 만들기
       </DialogTitle>
-      <DialogContent sx={{ pt: 1, pb: 1 }}>
-        <Stack spacing={2.5}>
+      <DialogContent sx={{ pt: 2, pb: 2, px: 3 }}>
+        <Stack spacing={3}>
           <Box>
             <Typography
               variant="subtitle2"
               sx={{
-                mb: 0.75,
+                mb: 1,
                 fontWeight: 600,
-                color: '#111827'
+                color: '#212121',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 0.5
               }}
             >
               AI 역할
@@ -60,20 +85,32 @@ export default function CreateRoleplayDialog({
               placeholder="예: Project Manager"
               sx={{
                 '& .MuiOutlinedInput-root': {
-                  backgroundColor: '#F9FAFB',
-                  borderRadius: 2,
+                  backgroundColor: '#FFFFFF',
+                  borderRadius: 2.5,
+                  transition: 'all 0.3s ease',
                   '& fieldset': {
-                    borderColor: 'rgba(0,0,0,0.12)'
+                    borderColor: 'rgba(124,108,255,0.3)',
+                    borderWidth: 2
                   },
-                  '&:hover fieldset': {
-                    borderColor: 'rgba(0,0,0,0.25)'
+                  '&:hover': {
+                    backgroundColor: 'rgba(124,108,255,0.04)',
+                    '& fieldset': {
+                      borderColor: 'rgba(124,108,255,0.5)'
+                    }
                   },
-                  '&.Mui-focused fieldset': {
-                    borderColor: '#6C63FF'
+                  '&.Mui-focused': {
+                    backgroundColor: 'rgba(124,108,255,0.06)',
+                    '& fieldset': {
+                      borderColor: '#7C6CFF',
+                      borderWidth: 2,
+                      boxShadow: '0 0 0 3px rgba(124,108,255,0.15)'
+                    }
                   }
                 },
                 '& .MuiInputBase-input': {
-                  color: '#111827'
+                  color: '#212121',
+                  fontSize: '0.9375rem',
+                  fontWeight: 500
                 }
               }}
             />
@@ -82,9 +119,12 @@ export default function CreateRoleplayDialog({
             <Typography
               variant="subtitle2"
               sx={{
-                mb: 0.75,
+                mb: 1,
                 fontWeight: 600,
-                color: '#111827'
+                color: '#212121',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 0.5
               }}
             >
               나의 역할
@@ -97,20 +137,32 @@ export default function CreateRoleplayDialog({
               placeholder="예: Software Engineer"
               sx={{
                 '& .MuiOutlinedInput-root': {
-                  backgroundColor: '#F9FAFB',
-                  borderRadius: 2,
+                  backgroundColor: '#FFFFFF',
+                  borderRadius: 2.5,
+                  transition: 'all 0.3s ease',
                   '& fieldset': {
-                    borderColor: 'rgba(0,0,0,0.12)'
+                    borderColor: 'rgba(124,108,255,0.3)',
+                    borderWidth: 2
                   },
-                  '&:hover fieldset': {
-                    borderColor: 'rgba(0,0,0,0.25)'
+                  '&:hover': {
+                    backgroundColor: 'rgba(124,108,255,0.04)',
+                    '& fieldset': {
+                      borderColor: 'rgba(124,108,255,0.5)'
+                    }
                   },
-                  '&.Mui-focused fieldset': {
-                    borderColor: '#6C63FF'
+                  '&.Mui-focused': {
+                    backgroundColor: 'rgba(124,108,255,0.06)',
+                    '& fieldset': {
+                      borderColor: '#7C6CFF',
+                      borderWidth: 2,
+                      boxShadow: '0 0 0 3px rgba(124,108,255,0.15)'
+                    }
                   }
                 },
                 '& .MuiInputBase-input': {
-                  color: '#111827'
+                  color: '#212121',
+                  fontSize: '0.9375rem',
+                  fontWeight: 500
                 }
               }}
             />
@@ -119,9 +171,12 @@ export default function CreateRoleplayDialog({
             <Typography
               variant="subtitle2"
               sx={{
-                mb: 0.75,
+                mb: 1,
                 fontWeight: 600,
-                color: '#111827'
+                color: '#212121',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 0.5
               }}
             >
               목적 상황
@@ -133,23 +188,35 @@ export default function CreateRoleplayDialog({
               onChange={onSituationChange}
               placeholder="예: 프로젝트 일정 조율 및 리스크 논의"
               multiline
-              rows={3}
+              rows={4}
               sx={{
                 '& .MuiOutlinedInput-root': {
-                  backgroundColor: '#F9FAFB',
-                  borderRadius: 2,
+                  backgroundColor: '#FFFFFF',
+                  borderRadius: 2.5,
+                  transition: 'all 0.3s ease',
                   '& fieldset': {
-                    borderColor: 'rgba(0,0,0,0.12)'
+                    borderColor: 'rgba(124,108,255,0.3)',
+                    borderWidth: 2
                   },
-                  '&:hover fieldset': {
-                    borderColor: 'rgba(0,0,0,0.25)'
+                  '&:hover': {
+                    backgroundColor: 'rgba(124,108,255,0.04)',
+                    '& fieldset': {
+                      borderColor: 'rgba(124,108,255,0.5)'
+                    }
                   },
-                  '&.Mui-focused fieldset': {
-                    borderColor: '#6C63FF'
+                  '&.Mui-focused': {
+                    backgroundColor: 'rgba(124,108,255,0.06)',
+                    '& fieldset': {
+                      borderColor: '#7C6CFF',
+                      borderWidth: 2,
+                      boxShadow: '0 0 0 3px rgba(124,108,255,0.15)'
+                    }
                   }
                 },
                 '& .MuiInputBase-input': {
-                  color: '#111827'
+                  color: '#212121',
+                  fontSize: '0.9375rem',
+                  fontWeight: 500
                 }
               }}
             />
@@ -161,17 +228,28 @@ export default function CreateRoleplayDialog({
           )}
         </Stack>
       </DialogContent>
-      <DialogActions sx={{ px: 3, pb: 2.5, pt: 2, gap: 1 }}>
+      <DialogActions sx={{ px: 3, pb: 3, pt: 2, gap: 1.5 }}>
         <Button
           onClick={onClose}
           variant="outlined"
           sx={{
             flex: 1,
-            borderColor: 'rgba(0,0,0,0.2)',
-            color: '#374151',
+            py: 1.25,
+            borderRadius: 2.5,
+            borderColor: 'rgba(124,108,255,0.3)',
+            borderWidth: 2,
+            color: '#7C6CFF',
+            fontWeight: 600,
+            fontSize: '0.9375rem',
+            textTransform: 'none',
+            background: 'linear-gradient(135deg, rgba(124,108,255,0.05) 0%, rgba(75,60,248,0.03) 100%)',
+            transition: 'all 0.3s ease',
             '&:hover': {
-              borderColor: '#111827',
-              backgroundColor: 'rgba(0,0,0,0.04)'
+              borderColor: 'rgba(124,108,255,0.5)',
+              borderWidth: 2,
+              background: 'linear-gradient(135deg, rgba(124,108,255,0.12) 0%, rgba(75,60,248,0.08) 100%)',
+              transform: 'translateY(-2px)',
+              boxShadow: '0 4px 12px rgba(124,108,255,0.2)'
             }
           }}
         >
@@ -183,16 +261,29 @@ export default function CreateRoleplayDialog({
           disabled={loading}
           sx={{
             flex: 1,
-            background: 'linear-gradient(135deg, #6C63FF 0%, #4F46E5 100%)',
+            py: 1.25,
+            borderRadius: 2.5,
+            background: 'linear-gradient(135deg, #7C6CFF 0%, #4B3CF8 100%)',
+            boxShadow: '0 4px 16px rgba(124,108,255,0.3)',
             color: '#fff',
+            fontWeight: 600,
+            fontSize: '0.9375rem',
+            textTransform: 'none',
+            transition: 'all 0.3s ease',
             '&:hover': {
-              background: 'linear-gradient(135deg, #7a72ff 0%, #5b53ec 100%)'
+              background: 'linear-gradient(135deg, #8B7DFF 0%, #5B4DFF 100%)',
+              boxShadow: '0 6px 20px rgba(124,108,255,0.4)',
+              transform: 'translateY(-2px)'
+            },
+            '&:disabled': {
+              background: 'rgba(124,108,255,0.4)',
+              color: 'rgba(255,255,255,0.7)'
             }
           }}
         >
           {loading ? (
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, justifyContent: 'center' }}>
-              <CircularProgress size={16} color="inherit" />
+              <CircularProgress size={18} color="inherit" />
               생성 중...
             </Box>
           ) : (

--- a/src/features/roleplay/scenario-list/components/ScenarioList.jsx
+++ b/src/features/roleplay/scenario-list/components/ScenarioList.jsx
@@ -259,13 +259,24 @@ function ScenarioList({
               variant="outlined"
               sx={{
                 borderRadius: 3,
-                border: '1px dashed rgba(0,0,0,0.12)',
-                backgroundColor: 'rgba(0,0,0,0.02)'
+                border: '1px dashed rgba(124,108,255,0.25)',
+                background: 'linear-gradient(135deg, rgba(124,108,255,0.04) 0%, rgba(75,60,248,0.02) 100%)',
+                boxShadow: '0 6px 18px rgba(124,108,255,0.12)'
               }}
             >
-              <CardContent sx={{ py: 6 }}>
-                <Typography variant="body2" color="text.secondary" align="center">
-                  표시할 시나리오가 없습니다.
+              <CardContent sx={{ py: 6, textAlign: 'center' }}>
+                <Typography 
+                  variant="subtitle1" 
+                  sx={{ 
+                    fontWeight: 700,
+                    mb: 1,
+                    background: 'linear-gradient(135deg, #7C6CFF 0%, #4B3CF8 100%)',
+                    WebkitBackgroundClip: 'text',
+                    WebkitTextFillColor: 'transparent',
+                    backgroundClip: 'text'
+                  }}
+                >
+                  표시할 시나리오가 없습니다
                 </Typography>
               </CardContent>
             </Card>
@@ -277,4 +288,3 @@ function ScenarioList({
 }
 
 export default memo(ScenarioList)
-

--- a/src/features/roleplay/session/components/KeyboardButton.jsx
+++ b/src/features/roleplay/session/components/KeyboardButton.jsx
@@ -7,19 +7,26 @@ export default function KeyboardButton({ onClick, isActive = false }) {
     <IconButton
       onClick={onClick}
       sx={{
-        width: 40,
-        height: 40,
-        border: '1px solid rgba(0,0,0,0.23)',
-        backgroundColor: isActive ? 'rgba(124,108,255,0.2)' : 'rgba(0,0,0,0.04)',
-        color: '#212121',
+        width: 44,
+        height: 44,
+        border: isActive ? '2px solid #7C6CFF' : '1.5px solid rgba(124,108,255,0.2)',
+        backgroundColor: isActive 
+          ? '#FFFFFF' 
+          : '#FFFFFF',
+        color: '#7C6CFF',
+        borderRadius: 2.5,
+        boxShadow: 'none',
+        transition: 'all 0.2s ease',
         '&:hover': {
-          backgroundColor: isActive ? 'rgba(124,108,255,0.3)' : 'rgba(0,0,0,0.08)'
+          backgroundColor: '#f5f5f5',
+          borderColor: '#7C6CFF',
+          transform: 'none',
+          boxShadow: 'none'
         }
       }}
       aria-label="키보드 입력"
     >
-      <KeyboardIcon sx={{ fontSize: 20 }} />
+      <KeyboardIcon sx={{ fontSize: 22 }} />
     </IconButton>
   )
 }
-

--- a/src/features/roleplay/session/components/MessageBubble.jsx
+++ b/src/features/roleplay/session/components/MessageBubble.jsx
@@ -272,8 +272,8 @@ function MessageBubble({ message, index, showTranslation, onToggleTranslation })
             py: 1.5,
             borderRadius: 1,
             border: `1px solid ${style.borderColor}`,
-            backdropFilter: 'blur(8px)',
-            boxShadow: '0 4px 12px rgba(0,0,0,0.2)'
+            backdropFilter: 'none',
+            boxShadow: 'none'
           }}
         >
           <Typography 
@@ -376,4 +376,3 @@ export default React.memo(MessageBubble, (prevProps, nextProps) => {
     prevProps.index === nextProps.index
   )
 })
-

--- a/src/features/roleplay/session/components/MessageList.jsx
+++ b/src/features/roleplay/session/components/MessageList.jsx
@@ -12,18 +12,19 @@ export default function MessageList({ messages, bottomRef }) {
         overflowX: 'hidden',
         px: 1,
         py: 1,
+        backgroundColor: 'transparent',
         '&::-webkit-scrollbar': {
           width: '6px'
         },
         '&::-webkit-scrollbar-track': {
-          backgroundColor: 'rgba(0,0,0,0.02)',
+          backgroundColor: 'transparent',
           borderRadius: '3px'
         },
         '&::-webkit-scrollbar-thumb': {
-          backgroundColor: 'rgba(0,0,0,0.23)',
+          backgroundColor: 'rgba(0,0,0,0.2)',
           borderRadius: '3px',
           '&:hover': {
-            backgroundColor: 'rgba(0,0,0,0.4)'
+            backgroundColor: 'rgba(0,0,0,0.3)'
           }
         }
       }}
@@ -35,4 +36,3 @@ export default function MessageList({ messages, bottomRef }) {
     </Stack>
   )
 }
-

--- a/src/features/roleplay/session/components/MicButton.jsx
+++ b/src/features/roleplay/session/components/MicButton.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Box, IconButton, Stack, Typography } from '@mui/material'
+import { Box, IconButton, Typography } from '@mui/material'
 import MicNoneIcon from '@mui/icons-material/MicNone'
 import KeyboardButton from './KeyboardButton'
 
@@ -10,58 +10,78 @@ export default function MicButton({
   isKeyboardMode = false
 }) {
   return (
-    <Box sx={{ display: 'flex', justifyContent: 'center', py: 1 }}>
-      <Stack direction="row" spacing={1.5} alignItems="center">
-        {isKeyboardMode && (
-          <KeyboardButton 
-            onClick={onKeyboardToggle} 
-            isActive={isKeyboardMode}
-          />
-        )}
-        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-          {isRecording && (
-            <Typography 
-              variant="caption" 
-              sx={{ 
-                fontWeight: 600,
-                fontSize: '0.75rem',
-                color: 'rgba(0,0,0,0.85)',
-                mb: 0.5
-              }}
-            >
-              녹음 중
-            </Typography>
+    <Box 
+      sx={{ 
+        position: 'relative', 
+        display: 'flex', 
+        justifyContent: 'center', 
+        py: 1, 
+        minHeight: 88 
+      }}
+    >
+      <Box
+        sx={{
+          position: 'absolute',
+          left: '50%',
+          transform: 'translateX(-50%)',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 0.5
+        }}
+      >
+        {isRecording && (
+          <Typography 
+            variant="caption" 
+            sx={{ 
+              fontWeight: 600,
+              fontSize: '0.75rem',
+              color: 'rgba(0,0,0,0.85)'
+            }}
+          >
+            녹음 중
+          </Typography>
         )}
         <IconButton
           color="primary"
           onClick={onClick}
           sx={{
-            width: 56,
-            height: 56,
-            border: '1px solid rgba(0,0,0,0.23)',
-            backgroundColor: isRecording 
-              ? 'rgba(124,108,255,0.3)' 
-              : 'rgba(0,0,0,0.04)',
-            color: '#212121',
-            '&:hover': {
-              backgroundColor: isRecording 
-                ? 'rgba(124,108,255,0.4)' 
-                : 'rgba(0,0,0,0.08)'
-            }
+            width: 64,
+            height: 64,
+            border: 'none',
+            background: isRecording 
+              ? 'linear-gradient(135deg, #FF6B6B 0%, #FF5252 100%)' 
+              : 'linear-gradient(135deg, #7C6CFF 0%, #4B3CF8 100%)',
+            color: '#FFFFFF',
+            borderRadius: '50%',
+            boxShadow: 'none',
+            transition: 'transform 0.15s ease',
+            '&:hover': { background: isRecording 
+              ? 'linear-gradient(135deg, #FF7B7B 0%, #FF6262 100%)' 
+              : 'linear-gradient(135deg, #8B7DFF 0%, #5B4DFF 100%)' },
+            '&:active': { transform: 'scale(0.97)' }
           }}
           aria-label={isRecording ? '녹음 중지' : '녹음 시작'}
         >
-          <MicNoneIcon sx={{ fontSize: 24 }} />
+          <MicNoneIcon sx={{ fontSize: 28 }} />
         </IconButton>
-        </Box>
-        {!isKeyboardMode && (
+      </Box>
+
+      {!isKeyboardMode && (
+        <Box
+          sx={{
+            position: 'absolute',
+            top: '50%',
+            left: '50%',
+            transform: 'translate(-50%, -50%) translateX(90px)'
+          }}
+        >
           <KeyboardButton 
             onClick={onKeyboardToggle} 
             isActive={false}
           />
-        )}
-      </Stack>
+        </Box>
+      )}
     </Box>
   )
 }
-

--- a/src/features/roleplay/session/components/SessionHeader.jsx
+++ b/src/features/roleplay/session/components/SessionHeader.jsx
@@ -1,7 +1,12 @@
 import React from 'react'
-import { Box, Typography, Button } from '@mui/material'
+import { Box, Typography, IconButton, useMediaQuery, useTheme } from '@mui/material'
+import CloseIcon from '@mui/icons-material/Close'
 
 export default function SessionHeader({ title, onEndSession }) {
+  const theme = useTheme()
+  const isDesktop = useMediaQuery(theme.breakpoints.up('md'))
+  const displayTitle = title || 'Roleplay'
+
   return (
     <Box 
       sx={{ 
@@ -12,35 +17,52 @@ export default function SessionHeader({ title, onEndSession }) {
         py: 0
       }}
     >
-      <Box sx={{ width: 72 }} />
-      <Typography 
-        variant="h6" 
-        align="center" 
-        sx={{ 
-          fontWeight: 700, 
-          flex: 1,
-          fontSize: '0.9375rem',
-          color: '#212121'
-        }}
-      >
-        {title || 'Roleplay'}
-      </Typography>
-      <Button 
-        size="small" 
-        variant="outlined" 
+      <IconButton
+        size="small"
         onClick={onEndSession}
+        aria-label="세션 종료"
         sx={{
-          borderColor: 'rgba(0,0,0,0.4)',
-          color: '#212121',
+          border: '1px solid rgba(0,0,0,0.35)',
+          borderRadius: '8px',
+          width: 40,
+          height: 36,
+          mr: 1,
           '&:hover': {
-            borderColor: 'rgba(0,0,0,0.5)',
-            backgroundColor: 'rgba(0,0,0,0.08)'
+            backgroundColor: 'rgba(0,0,0,0.06)'
           }
         }}
       >
-        종료
-      </Button>
+        <CloseIcon fontSize="small" />
+      </IconButton>
+
+      <Box
+        sx={{
+          flex: 1,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          minWidth: 0
+        }}
+      >
+        <Typography 
+          variant="h6" 
+          align="center" 
+          noWrap
+          sx={{ 
+            fontWeight: 700, 
+            fontSize: '0.9375rem',
+            color: '#212121',
+            maxWidth: '100%',
+            textOverflow: 'ellipsis',
+            overflow: 'hidden',
+            whiteSpace: 'nowrap'
+          }}
+        >
+          {displayTitle}
+        </Typography>
+      </Box>
+
+      <Box sx={{ width: isDesktop ? 40 : 40 }} />
     </Box>
   )
 }
-

--- a/src/features/roleplay/session/components/SessionView.jsx
+++ b/src/features/roleplay/session/components/SessionView.jsx
@@ -30,7 +30,7 @@ export default function SessionView({
         display: 'flex',
         flexDirection: 'column',
         overflow: 'hidden',
-        backgroundColor: 'background.default'
+        backgroundColor: '#FFFFFF'
       }}
     >
       <SessionHeader title={selectedTitle} onEndSession={onEndSession} />

--- a/src/features/roleplay/session/components/TextInputArea.jsx
+++ b/src/features/roleplay/session/components/TextInputArea.jsx
@@ -1,8 +1,6 @@
 import React from 'react'
-import { Box, TextField, IconButton, Stack } from '@mui/material'
-import SendIcon from '@mui/icons-material/Send'
+import { Box, TextField, IconButton } from '@mui/material'
 import MicNoneIcon from '@mui/icons-material/MicNone'
-import KeyboardButton from './KeyboardButton'
 
 export default function TextInputArea({ 
   value, 
@@ -29,9 +27,9 @@ export default function TextInputArea({
         flexDirection: 'column',
         gap: 1,
         p: 1.5,
-        backgroundColor: 'rgba(0,0,0,0.02)',
-        borderTop: '1px solid rgba(0,0,0,0.1)',
-        borderRadius: '0 0 12px 12px'
+        backgroundColor: 'transparent',
+        borderTop: 'none',
+        borderRadius: 0
       }}
     >
       <Box
@@ -53,7 +51,7 @@ export default function TextInputArea({
           size="small"
           sx={{
             '& .MuiOutlinedInput-root': {
-              backgroundColor: 'rgba(0,0,0,0.04)',
+              backgroundColor: '#ffffff',
               borderRadius: 2,
               color: '#212121',
               '& fieldset': {
@@ -76,50 +74,22 @@ export default function TextInputArea({
           }}
         />
         <IconButton
-          onClick={onSend}
-          disabled={!value.trim()}
-          sx={{
-            width: 40,
-            height: 40,
-            backgroundColor: value.trim() ? 'rgba(124,108,255,0.3)' : 'rgba(0,0,0,0.04)',
-            color: value.trim() ? '#212121' : 'rgba(245,246,255,0.4)',
-            border: '1px solid rgba(0,0,0,0.23)',
-            '&:hover': {
-              backgroundColor: value.trim() ? 'rgba(124,108,255,0.4)' : 'rgba(0,0,0,0.08)'
-            },
-            '&.Mui-disabled': {
-              backgroundColor: 'rgba(0,0,0,0.02)',
-              borderColor: 'rgba(0,0,0,0.1)'
-            }
-          }}
-          aria-label="전송"
-        >
-          <SendIcon sx={{ fontSize: 20 }} />
-        </IconButton>
-      </Box>
-      <Stack direction="row" spacing={1.5} justifyContent="center" alignItems="center">
-        <IconButton
           onClick={onMicToggle}
           sx={{
             width: 40,
             height: 40,
-            border: '1px solid rgba(0,0,0,0.23)',
-            backgroundColor: 'rgba(0,0,0,0.04)',
+            backgroundColor: '#ffffff',
             color: '#212121',
+            border: '1px solid rgba(0,0,0,0.2)',
             '&:hover': {
-              backgroundColor: 'rgba(0,0,0,0.08)'
+              backgroundColor: '#f5f5f5'
             }
           }}
-          aria-label="마이크"
+          aria-label="음성 모드로 전환"
         >
           <MicNoneIcon sx={{ fontSize: 20 }} />
         </IconButton>
-        <KeyboardButton 
-          onClick={onKeyboardToggle} 
-          isActive={isKeyboardMode}
-        />
-      </Stack>
+      </Box>
     </Box>
   )
 }
-

--- a/src/features/roleplay/session/hooks/useRoleplaySession.js
+++ b/src/features/roleplay/session/hooks/useRoleplaySession.js
@@ -557,7 +557,7 @@ export default function useRoleplaySession() {
       displayFeedbackMessages(pendingFeedbackSectionsRef.current)
       pendingFeedbackSectionsRef.current = []
     }
-    endSession()
+    endSession('auto')
   }
 
   /**
@@ -819,7 +819,7 @@ export default function useRoleplaySession() {
   /**
    * 롤플레이 세션 종료
    */
-  const endSession = () => {
+  const endSession = (reason = 'user') => {
     stopTTS()
     
     if (isRecording) {
@@ -834,11 +834,8 @@ export default function useRoleplaySession() {
     setIsInitialized(false)
     setIsAvatarLoaded(false)
     pendingFirstMessageRef.current = null
-    setEvaluating(true)
-    setTimeout(() => {
-      setEvaluating(false)
-      handleFeedbackView(selectedTitle, selectedBody)
-    }, EVALUATION_DELAY_MS)
+    setEvaluating(false)
+    setView(reason === 'auto' ? 'summary' : 'list')
   }
 
   /**

--- a/src/features/roleplay/session/hooks/useSessionControls.js
+++ b/src/features/roleplay/session/hooks/useSessionControls.js
@@ -65,7 +65,7 @@ export default function useSessionControls(scenarios = []) {
    */
   const handleEndSession = () => {
     setOpenEnd(false)
-    session.endSession()
+    session.endSession('user')
   }
 
   return {
@@ -91,4 +91,3 @@ export default function useSessionControls(scenarios = []) {
     handleEndSession
   }
 }
-

--- a/src/features/roleplay/summary/components/SummaryView.jsx
+++ b/src/features/roleplay/summary/components/SummaryView.jsx
@@ -1,20 +1,16 @@
 import React from 'react'
-import { 
-  Stack, 
-  Card, 
-  CardContent, 
-  Typography, 
-  Box, 
-  Button, 
-  Chip,
+import {
+  Stack,
+  Card,
+  CardContent,
+  Typography,
+  Box,
   IconButton,
   Divider,
-  Collapse
+  Collapse,
+  Button
 } from '@mui/material'
-import PlayArrowIcon from '@mui/icons-material/PlayArrow'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
-
-
 
 const normalizeConversationMessages = (rawMessages = []) => {
   if (!Array.isArray(rawMessages)) return []
@@ -36,165 +32,82 @@ export default function SummaryView({
   onClose,
   scenarioTitle = '롤플레잉 시나리오'
 }) {
-  const [isConversationOpen, setIsConversationOpen] = React.useState(false)
-  
+  const [isConversationOpen, setIsConversationOpen] = React.useState(true)
+  const [isLongOpen, setIsLongOpen] = React.useState(false)
+
   const normalizedMessages = normalizeConversationMessages(messages)
   const displayMessages = normalizedMessages.length > 0 ? normalizedMessages : MOCK_CONVERSATION
-  
+
+  const SHORT_FEEDBACK = '짧은 종합 피드백 더미: 이번 대화에서 핵심 의도를 잘 전달했고 흐름이 자연스러웠습니다.'
+  const LONG_FEEDBACK =
+    '긴 종합 피드백 더미: 이번 롤플레잉에서는 상황 이해와 맥락 유지가 전반적으로 우수했습니다. 다만 몇 차례 문법적 어색함이 있었고, 특정 질문에 답변이 길어졌습니다. 다음 연습에서는 핵심 메시지를 간결하게 전달하고, 일정한 발음과 억양을 유지해 보세요.'
+
   return (
     <Box sx={{ py: { xs: 2, sm: 3 }, px: { xs: 0, sm: 0 } }}>
       <Stack spacing={3}>
         {/* 헤더 */}
         <Stack spacing={0.5} alignItems="center" textAlign="center">
-          <Typography variant="h4" sx={{ fontWeight: 700 }}>
-            피드백
+          <Typography variant="overline" sx={{ letterSpacing: 1.2, color: 'text.secondary' }}>
+            롤플레잉 종합 피드백
           </Typography>
-          <Typography variant="body2" color="text.secondary" sx={{ opacity: 0.75 }}>
-            롤플레잉 세션에 대한 상세 피드백을 확인하세요
+          <Typography variant="h5" sx={{ fontWeight: 800 }}>
+            {scenarioTitle || '롤플레잉 시나리오'}
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ opacity: 0.8 }}>
+            짧은 요약과 상세 피드백을 확인하고 대화 로그를 복기하세요.
           </Typography>
         </Stack>
 
-        {/* 🎤 발음 평가 요약 */}
+        {/* 종합 피드백 */}
+        <Card
+          variant="outlined"
+          sx={{
+            borderRadius: 3,
+            border: '1px solid rgba(124,108,255,0.2)',
+            background: 'linear-gradient(135deg, rgba(124,108,255,0.04) 0%, rgba(75,60,248,0.02) 100%)',
+            boxShadow: '0 8px 24px rgba(124,108,255,0.12)'
+          }}
+        >
+          <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            <Box>
+              <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.5 }}>
+                짧은 버전
+              </Typography>
+              <Typography variant="body2" color="text.primary">
+                {SHORT_FEEDBACK}
+              </Typography>
+            </Box>
+
+            <Divider />
+
+            <Box>
+              <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
+                  긴 버전
+                </Typography>
+                <IconButton
+                  size="small"
+                  onClick={() => setIsLongOpen((prev) => !prev)}
+                  sx={{ transform: isLongOpen ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 0.2s ease' }}
+                >
+                  <ExpandMoreIcon fontSize="small" />
+                </IconButton>
+              </Box>
+              <Collapse in={isLongOpen} timeout="auto" unmountOnExit>
+                <Typography variant="body2" color="text.primary" sx={{ mt: 1 }}>
+                  {LONG_FEEDBACK}
+                </Typography>
+              </Collapse>
+            </Box>
+          </CardContent>
+        </Card>
+
+        {/* 대화 로그 */}
         <Box>
-          <Typography variant="subtitle1" fontWeight={700} sx={{ mb: 2.5 }}>
-            발음 평가 요약
-          </Typography>
-          <Stack 
-            direction={{ xs: 'row', sm: 'row' }} 
-            spacing={1.5}
-            sx={{ 
-              overflowX: { xs: 'auto', sm: 'visible' },
-              pb: { xs: 1, sm: 0 },
-              '&::-webkit-scrollbar': { display: 'none' }
-            }}
-          >
-            {/* 정확도 카드 */}
-            <Card 
-              variant="outlined" 
-              sx={{ 
-                minWidth: { xs: '30%', sm: 'auto' },
-                flex: { xs: '0 0 auto', sm: 1 },
-                bgcolor: 'rgba(0,0,0,0.03)',
-                border: '1px solid rgba(0,0,0,0.1)',
-                transition: 'all 0.2s ease',
-                '&:hover': {
-                  bgcolor: 'rgba(0,0,0,0.05)',
-                  transform: 'translateY(-2px)',
-                  boxShadow: '0 4px 12px rgba(0,0,0,0.2)'
-                }
-              }}
-            >
-              <CardContent sx={{ textAlign: 'center', py: 2.5 }}>
-                <Typography 
-                  variant="h3" 
-                  sx={{ 
-                    fontWeight: 700, 
-                    mb: 0.5,
-                    background: 'linear-gradient(135deg, #7C6CFF 0%, #4B3CF8 100%)',
-                    WebkitBackgroundClip: 'text',
-                    WebkitTextFillColor: 'transparent',
-                    backgroundClip: 'text'
-                  }}
-                >
-                  {MOCK_PRONUNCIATION_SCORES.accuracy}
-                </Typography>
-                <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
-                  정확도
-                </Typography>
-                <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.7rem' }}>
-                  Accuracy
-                </Typography>
-              </CardContent>
-            </Card>
-
-            {/* 유창성 카드 */}
-            <Card 
-              variant="outlined"
-              sx={{ 
-                minWidth: { xs: '30%', sm: 'auto' },
-                flex: { xs: '0 0 auto', sm: 1 },
-                bgcolor: 'rgba(0,0,0,0.03)',
-                border: '1px solid rgba(0,0,0,0.1)',
-                transition: 'all 0.2s ease',
-                '&:hover': {
-                  bgcolor: 'rgba(0,0,0,0.05)',
-                  transform: 'translateY(-2px)',
-                  boxShadow: '0 4px 12px rgba(0,0,0,0.2)'
-                }
-              }}
-            >
-              <CardContent sx={{ textAlign: 'center', py: 2.5 }}>
-                <Typography 
-                  variant="h3" 
-                  sx={{ 
-                    fontWeight: 700, 
-                    mb: 0.5,
-                    background: 'linear-gradient(135deg, #7C6CFF 0%, #4B3CF8 100%)',
-                    WebkitBackgroundClip: 'text',
-                    WebkitTextFillColor: 'transparent',
-                    backgroundClip: 'text'
-                  }}
-                >
-                  {MOCK_PRONUNCIATION_SCORES.fluency}
-                </Typography>
-                <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
-                  유창성
-                </Typography>
-                <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.7rem' }}>
-                  Fluency
-                </Typography>
-              </CardContent>
-            </Card>
-
-            {/* 억양강세 카드 */}
-            <Card 
-              variant="outlined"
-              sx={{ 
-                minWidth: { xs: '30%', sm: 'auto' },
-                flex: { xs: '0 0 auto', sm: 1 },
-                bgcolor: 'rgba(0,0,0,0.03)',
-                border: '1px solid rgba(0,0,0,0.1)',
-                transition: 'all 0.2s ease',
-                '&:hover': {
-                  bgcolor: 'rgba(0,0,0,0.05)',
-                  transform: 'translateY(-2px)',
-                  boxShadow: '0 4px 12px rgba(0,0,0,0.2)'
-                }
-              }}
-            >
-              <CardContent sx={{ textAlign: 'center', py: 2.5 }}>
-                <Typography 
-                  variant="h3" 
-                  sx={{ 
-                    fontWeight: 700, 
-                    mb: 0.5,
-                    background: 'linear-gradient(135deg, #7C6CFF 0%, #4B3CF8 100%)',
-                    WebkitBackgroundClip: 'text',
-                    WebkitTextFillColor: 'transparent',
-                    backgroundClip: 'text'
-                  }}
-                >
-                  {MOCK_PRONUNCIATION_SCORES.prosody}
-                </Typography>
-                <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
-                  억양·강세
-                </Typography>
-                <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.7rem' }}>
-                  Prosody
-                </Typography>
-              </CardContent>
-            </Card>
-          </Stack>
-        </Box>
-
-        <Divider sx={{ my: 1, borderColor: 'rgba(0,0,0,0.1)' }} />
-
-        {/* 🗨️ 대화 로그 */}
-        <Box>
-          <Box 
-            sx={{ 
-              display: 'flex', 
-              alignItems: 'center', 
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
               justifyContent: 'space-between',
               mb: 2,
               cursor: 'pointer',
@@ -205,265 +118,85 @@ export default function SummaryView({
                 bgcolor: 'rgba(0,0,0,0.03)'
               }
             }}
-            onClick={() => setIsConversationOpen(!isConversationOpen)}
+            onClick={() => setIsConversationOpen((prev) => !prev)}
           >
             <Typography variant="subtitle1" fontWeight={700}>
               대화 로그
             </Typography>
-            <IconButton 
+            <IconButton
               size="small"
-              sx={{ 
+              sx={{
                 color: 'text.primary',
                 transition: 'transform 0.2s ease',
                 transform: isConversationOpen ? 'rotate(180deg)' : 'rotate(0deg)'
               }}
             >
-              <ExpandMoreIcon />
+              <ExpandMoreIcon fontSize="small" />
             </IconButton>
           </Box>
-          <Collapse in={isConversationOpen}>
-            <Stack spacing={2.5}>
-            {displayMessages.map((message, index) => {
-              const isAI = message.who === 'AI'
-              const isUser = message.who === 'You' || message.who === 'USER'
-              
-              // 사용자 발화에만 피드백 표시
-              const userIndex = Math.floor(index / 2) // 사용자 발화 인덱스 (0부터 시작)
-              const utteranceFeedback = isUser ? {
-                accuracy: 82 + (userIndex % 10),
-                fluency: 75 + (userIndex % 12),
-                prosody: 78 + (userIndex % 11),
-                feedback: `이 발화는 전반적으로 명확했습니다. "${message.text.split(' ').slice(0, 4).join(' ')}" 부분의 강세와 리듬을 더 자연스럽게 하면 좋겠습니다.`
-              } : null
 
-              return (
-                <Box key={index}>
-                  {/* AI 질문 */}
-                  {isAI && (
-                    <Box
-                      sx={{
-                        display: 'flex',
-                        flexDirection: 'column',
-                        alignItems: 'flex-start',
-                        mb: 1
-                      }}
-                    >
-                      <Box
+          <Collapse in={isConversationOpen} timeout="auto" unmountOnExit>
+            <Stack spacing={1.5}>
+              {displayMessages.map((msg, idx) => {
+                const isUser = msg.who === 'You'
+                return (
+                  <Box key={`${msg.who}-${idx}`} sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+                    <Stack direction="row" spacing={1} alignItems="center">
+                      <Typography
+                        variant="caption"
                         sx={{
-                          maxWidth: '88%',
-                          px: 1.5,
-                          py: 1,
-                          borderRadius: 2,
-                          bgcolor: 'rgba(0,0,0,0.08)',
-                          border: '1px solid rgba(0,0,0,0.15)',
-                          backdropFilter: 'blur(6px)'
+                          fontWeight: 700,
+                          color: isUser ? 'primary.main' : 'text.primary',
+                          textTransform: 'uppercase'
                         }}
                       >
-                        <Typography variant="caption" sx={{ opacity: 0.7, display: 'block', mb: 0.5 }}>
-                          AI
+                        {isUser ? 'You' : 'AI'}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        #{idx + 1}
+                      </Typography>
+                    </Stack>
+                    <Card
+                      variant="outlined"
+                      sx={{
+                        alignSelf: isUser ? 'flex-end' : 'flex-start',
+                        maxWidth: '88%',
+                        bgcolor: isUser ? 'rgba(124,108,255,0.08)' : 'rgba(0,0,0,0.03)',
+                        border: isUser ? '1px solid rgba(124,108,255,0.25)' : '1px solid rgba(0,0,0,0.1)',
+                        borderRadius: 2,
+                        boxShadow: '0 6px 16px rgba(0,0,0,0.08)'
+                      }}
+                    >
+                      <CardContent sx={{ py: 1.5, px: 2 }}>
+                        <Typography variant="body2" color="text.primary" sx={{ whiteSpace: 'pre-wrap' }}>
+                          {msg.text}
                         </Typography>
-                        <Typography variant="body2" sx={{ color: '#212121' }}>{message.text}</Typography>
-                      </Box>
-                    </Box>
-                  )}
-
-                  {/* 사용자 답변 + 피드백 + 제안 */}
-                  {isUser && (
-                    <Box
-                      sx={{
-                        display: 'flex',
-                        flexDirection: 'column',
-                        alignItems: 'flex-end',
-                        gap: 1
-                      }}
-                    >
-                      {/* 사용자 발화 */}
-                      <Box
-                        sx={{
-                          maxWidth: '88%',
-                          px: 1.5,
-                          py: 1,
-                          borderRadius: 2,
-                          bgcolor: 'rgba(124,108,255,0.25)',
-                          border: '1px solid rgba(124,108,255,0.4)',
-                          backdropFilter: 'blur(6px)'
-                        }}
-                      >
-                        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 1 }}>
-                          <Box sx={{ flex: 1 }}>
-                            <Typography variant="caption" sx={{ opacity: 0.7, display: 'block', mb: 0.5 }}>
-                              You
-                            </Typography>
-                            <Typography variant="body2" sx={{ color: '#212121' }}>{message.text}</Typography>
-                          </Box>
-                          {/* 오디오 재생 버튼 (Optional) */}
-                          <IconButton size="small" sx={{ ml: 1, color: 'rgba(0,0,0,0.6)' }}>
-                            <PlayArrowIcon fontSize="small" />
-                          </IconButton>
-                        </Box>
-                      </Box>
-
-                      {/* 발화별 피드백 카드 */}
-                      {utteranceFeedback && (
-                        <Card 
-                          variant="outlined" 
-                          sx={{ 
-                            maxWidth: '88%',
-                            bgcolor: 'rgba(0,0,0,0.03)',
-                            border: '1px dashed rgba(0,0,0,0.23)',
-                            backdropFilter: 'blur(6px)'
-                          }}
-                        >
-                          <CardContent sx={{ py: 1.5, px: 1.5 }}>
-                            <Stack direction="row" spacing={1} sx={{ mb: 1, flexWrap: 'wrap', gap: 0.5 }}>
-                              <Chip 
-                                label={`정확도 ${utteranceFeedback.accuracy}`} 
-                                size="small" 
-                                variant="outlined"
-                                sx={{ 
-                                  fontSize: '0.7rem', 
-                                  height: 20,
-                                  borderColor: 'rgba(0,0,0,0.4)',
-                                  color: '#212121'
-                                }}
-                              />
-                              <Chip 
-                                label={`유창성 ${utteranceFeedback.fluency}`} 
-                                size="small" 
-                                variant="outlined"
-                                sx={{ 
-                                  fontSize: '0.7rem', 
-                                  height: 20,
-                                  borderColor: 'rgba(0,0,0,0.4)',
-                                  color: '#212121'
-                                }}
-                              />
-                              <Chip 
-                                label={`억양 ${utteranceFeedback.prosody}`} 
-                                size="small" 
-                                variant="outlined"
-                                sx={{ 
-                                  fontSize: '0.7rem', 
-                                  height: 20,
-                                  borderColor: 'rgba(0,0,0,0.4)',
-                                  color: '#212121'
-                                }}
-                              />
-                            </Stack>
-                            <Typography variant="body2" sx={{ fontSize: '0.8125rem', color: '#212121' }}>
-                              {utteranceFeedback.feedback}
-                            </Typography>
-                          </CardContent>
-                        </Card>
-                      )}
-
-                    </Box>
-                  )}
-                </Box>
-              )
-            })}
+                        {msg.translation && (
+                          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.75 }}>
+                            {msg.translation}
+                          </Typography>
+                        )}
+                      </CardContent>
+                    </Card>
+                  </Box>
+                )
+              })}
             </Stack>
           </Collapse>
         </Box>
 
-        <Divider sx={{ my: 1, borderColor: 'rgba(0,0,0,0.1)' }} />
-
-        {/* 🧠 전체 피드백 (LLM) */}
-        <Box>
-          <Typography variant="subtitle1" fontWeight={700} sx={{ mb: 2.5 }}>
-            전체 피드백
-          </Typography>
-          <Card 
-            variant="outlined"
-            sx={{
-              bgcolor: 'rgba(0,0,0,0.03)',
-              border: '1px solid rgba(0,0,0,0.1)',
-              backdropFilter: 'blur(6px)'
-            }}
-          >
-            <CardContent sx={{ py: 3, px: 2.5 }}>
-              <Stack spacing={3}>
-                {/* 종합 평가 */}
-                <Box>
-                  <Typography variant="body2" fontWeight={600} sx={{ mb: 1.5, color: 'text.primary' }}>
-                    종합 평가
-                  </Typography>
-                  <Typography variant="body2" color="text.primary" sx={{ lineHeight: 1.7 }}>
-                    {MOCK_FEEDBACK_DATA.overall.summary}
-                  </Typography>
-                </Box>
-
-                <Divider sx={{ my: 2, borderColor: 'rgba(0,0,0,0.1)' }} />
-
-                {/* 부족한 부분 */}
-                <Box>
-                  <Typography variant="body2" fontWeight={600} sx={{ mb: 1.5, color: 'text.primary' }}>
-                    부족한 부분
-                  </Typography>
-                  <Stack spacing={1}>
-                    {MOCK_FEEDBACK_DATA.overall.weaknesses.map((weakness, idx) => (
-                      <Box 
-                        key={idx} 
-                        sx={{ 
-                          display: 'flex', 
-                          alignItems: 'flex-start', 
-                          gap: 1.5,
-                          p: 1,
-                          borderRadius: 1,
-                          bgcolor: 'rgba(255,193,7,0.1)',
-                          border: '1px solid rgba(255,193,7,0.2)'
-                        }}
-                      >
-                        <Typography variant="body2" sx={{ color: 'warning.main', fontWeight: 700 }}>•</Typography>
-                        <Typography variant="body2" color="text.primary">{weakness}</Typography>
-                      </Box>
-                    ))}
-                  </Stack>
-                </Box>
-
-                <Divider sx={{ my: 2, borderColor: 'rgba(0,0,0,0.1)' }} />
-
-                {/* 개선 팁 */}
-                <Box>
-                  <Typography variant="body2" fontWeight={600} sx={{ mb: 1.5, color: 'text.primary' }}>
-                    개선 팁
-                  </Typography>
-                  <Stack spacing={1}>
-                    {MOCK_FEEDBACK_DATA.overall.tips.map((tip, idx) => (
-                      <Box 
-                        key={idx} 
-                        sx={{ 
-                          display: 'flex', 
-                          alignItems: 'flex-start', 
-                          gap: 1.5,
-                          p: 1,
-                          borderRadius: 1,
-                          bgcolor: 'rgba(124,108,255,0.1)',
-                          border: '1px solid rgba(124,108,255,0.2)'
-                        }}
-                      >
-                        <Typography variant="body2" sx={{ color: 'primary.main', fontWeight: 700 }}>•</Typography>
-                        <Typography variant="body2" color="text.primary">{tip}</Typography>
-                      </Box>
-                    ))}
-                  </Stack>
-                </Box>
-
-                <Divider sx={{ my: 2, borderColor: 'rgba(0,0,0,0.1)' }} />
-                
-              </Stack>
-            </CardContent>
-          </Card>
-        </Box>
-
-        <Button 
-          variant="outlined" 
-          onClick={onClose}
-          sx={{ mt: 2 }}
-        >
+        <Button variant="outlined" onClick={onClose} sx={{ mt: 2 }}>
           닫기
         </Button>
       </Stack>
     </Box>
   )
 }
+
+// 더미 데이터
+const MOCK_CONVERSATION = [
+  { who: 'AI', text: 'What is your role in the project?' },
+  { who: 'You', text: 'I handle frontend development and UX validation.' },
+  { who: 'AI', text: 'How do you prioritize feature requests?' },
+  { who: 'You', text: 'We use impact vs. effort scoring and run quick user tests.' }
+]

--- a/src/features/user/components/ProfileSummary.jsx
+++ b/src/features/user/components/ProfileSummary.jsx
@@ -82,6 +82,7 @@ export default function ProfileSummary() {
       <CardContent sx={{ p: 3 }}>
         <Stack direction="row" spacing={2.5} alignItems="flex-start">
           <Avatar 
+            variant="rounded"
             sx={{ 
               width: 80, 
               height: 80, 
@@ -89,7 +90,8 @@ export default function ProfileSummary() {
               border: '3px solid rgba(255,255,255,0.9)',
               fontSize: '1.75rem',
               fontWeight: 700,
-              boxShadow: '0 4px 12px rgba(124,108,255,0.3)'
+              boxShadow: '0 4px 12px rgba(124,108,255,0.3)',
+              borderRadius: 1
             }}
           >
             {userInitials}
@@ -114,7 +116,7 @@ export default function ProfileSummary() {
               <Chip
                 icon={<LocalFireDepartmentIcon sx={{ fontSize: 18 }} />}
                 label={`${streakDays}일 연속 학습 중`}
-                sx={{
+                sx={{ 
                   width: 'fit-content',
                   background: 'linear-gradient(135deg, rgba(255,152,0,0.15) 0%, rgba(255,193,7,0.15) 100%)',
                   border: '1px solid rgba(255,152,0,0.3)',
@@ -144,8 +146,8 @@ export default function ProfileSummary() {
                     backgroundClip: 'text'
                   }}>
                     {completionStats.completed}/{completionStats.total} ({completionStats.percentage}%)
-                  </Typography>
-                </Box>
+              </Typography>
+            </Box>
                 <LinearProgress 
                   variant="determinate" 
                   value={completionStats.percentage} 
@@ -169,4 +171,3 @@ export default function ProfileSummary() {
     </Card>
   )
 }
-

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -129,7 +129,7 @@ const theme = createTheme({
           '& input': {
             color: '#212121 !important',
             WebkitTextFillColor: '#212121 !important'
-          },
+        },
           '& input[type=password]': {
             color: '#212121 !important',
             WebkitTextFillColor: '#212121 !important',

--- a/src/services/roleplayService.js
+++ b/src/services/roleplayService.js
@@ -28,30 +28,36 @@ export async function fetchUserScenarios() {
 
 /**
  * 프롬프트 기반 시나리오 요청
- * @param {Object} promptData - 프롬프트 데이터
- * @returns {Promise<Object>}
+ * Gateway에서 FastAPI URL과 userId를 받아옴
+ * @param {Object} promptData - 프롬프트 데이터 { myRole, aiRole, situation }
+ * @returns {Promise<Object>} { userId, fastapi_url }
  */
 export async function requestPromptScenario(promptData) {
-  const url = `${API_ENDPOINTS.GATEWAY}/scenarios/prompt`
+  const url = `${API_ENDPOINTS.GATEWAY}/scenarios/roleplaying/generate-from-prompt`
   return httpClient.post(url, promptData)
 }
 
 /**
  * FastAPI에서 시나리오 생성
- * @param {Object} scenarioData - 시나리오 데이터
- * @returns {Promise<Object>}
+ * Gateway를 통해 FastAPI로 프록시
+ * @param {Object} scenarioData - 시나리오 데이터 { fastapi_url, userId, myRole, aiRole, situation }
+ * @returns {Promise<Object>} { scenario: { aiRole, topicType, title, fixedQuestions, creationType } }
  */
 export async function generateScenarioFromFastApi(scenarioData) {
+  const { fastapi_url, ...requestBody } = scenarioData
+  // Gateway를 통해 FastAPI로 프록시
   const url = `${API_ENDPOINTS.GATEWAY}/scenarios/generate`
-  return httpClient.post(url, scenarioData)
+  return httpClient.post(url, requestBody)
 }
 
 /**
  * Spring2에 시나리오 저장
- * @param {Object} scenarioData - 시나리오 데이터
- * @returns {Promise<Object>}
+ * Gateway를 통해 Spring2로 프록시
+ * @param {Object} scenarioData - 시나리오 데이터 { userId, myRole, situation, scenario: { aiRole, topicType, title, fixedQuestions } }
+ * @returns {Promise<Object>} { subjectId, scenarioId }
  */
 export async function saveScenarioToSpring2(scenarioData) {
+  // Gateway를 통해 Spring2로 프록시
   const url = `${API_ENDPOINTS.GATEWAY}/scenarios`
   return httpClient.post(url, scenarioData)
 }
@@ -59,11 +65,12 @@ export async function saveScenarioToSpring2(scenarioData) {
 /**
  * 롤플레이 세션 시작
  * @param {number} scenarioId - 시나리오 ID
+ * @param {string} interactionMode - 상호작용 모드 (기본값: "default")
  * @returns {Promise<Object>} 세션 정보
  */
-export async function startSession(scenarioId) {
+export async function startSession(scenarioId, interactionMode = 'default') {
   const url = `${API_ENDPOINTS.GATEWAY}/roleplaying/sessions`
-  return httpClient.post(url, { scenarioId })
+  return httpClient.post(url, { scenarioId, interactionMode })
 }
 
 /**


### PR DESCRIPTION
## 🧩 개요
롤플레잉 UI를 전반적으로 리디자인했습니다. 시나리오 없음 상태 카드 스타일 개선, 마이크/키보드 버튼 레이아웃 단순화, 채팅 버블과 입력 영역의 그림자·배경 정리, 요약 화면에 짧은/긴 피드백 더미와 대화 로그 표시, 세션 종료 시 정상 종료는 요약 뷰로 이동하도록 동작을 조정했습니다.

## 🔗 관련 이슈
Closes #

## 🌿 브랜치 정보
- 브랜치 이름: `feature/<이슈번호>-<작업내용>` 또는 `fix/<이슈번호>-<수정내용>`
- 기준 브랜치: `develop`

> 브랜치 이름 규칙이 맞지 않으면 리뷰 요청 전에 수정해주세요.

## ✅ 변경 사항
- [ ] 세션 종료 플로우 분기: 정상 종료 시 요약 뷰로 이동, 수동 종료는 리스트로 복귀하도록 endSession 로직 수정.
- [ ] UI 리디자인: 마이크/키보드 레이아웃 단순화, 입력창·채팅 버블 그림자/배경 정리, 시나리오 빈 상태 카드 테마 적용.
- [ ] 요약 화면 개선: 짧은/긴 더미 종합 피드백 추가 및 대화 로그 토글 표시로 세션 요약 가독성 향상.

## 🧪 테스트
이 변경을 어떻게 검증했나요?

## 📸 참고 자료
(선택) 스크린샷, 로그 등

---

> 💡 **PR 생성 시 “Closes #이슈번호”를 포함하면**  
> 병합 시 해당 이슈가 자동으로 닫힙니다.
