### PR TITLE
feat: 종합 피드백 프론트 연동

### DIFF
--- a/src/components/Common/ErrorBoundary.jsx
+++ b/src/components/Common/ErrorBoundary.jsx
@@ -108,3 +108,7 @@ export default ErrorBoundary
 
 
 
+
+
+
+

--- a/src/components/Common/LoadingSpinner.jsx
+++ b/src/components/Common/LoadingSpinner.jsx
@@ -36,3 +36,7 @@ export default function LoadingSpinner({ message = '로딩 중...' }) {
 
 
 
+
+
+
+

--- a/src/components/Route/ProtectedRoute.jsx
+++ b/src/components/Route/ProtectedRoute.jsx
@@ -28,3 +28,7 @@ export default function ProtectedRoute({ children }) {
 
 
 
+
+
+
+

--- a/src/features/roleplay/pages/RoleplayPage.jsx
+++ b/src/features/roleplay/pages/RoleplayPage.jsx
@@ -173,6 +173,7 @@ export default function RoleplayPage() {
         <SummaryView
           messages={session.messages}
           scenarioTitle={session.selectedTitle}
+          sessionId={session.sessionInfo?.sessionId || session.sessionInfo?.session_id}
           onClose={() => session.setView('list')}
         />
       </Suspense>

--- a/src/features/roleplay/session/hooks/useRoleplaySession.js
+++ b/src/features/roleplay/session/hooks/useRoleplaySession.js
@@ -1186,6 +1186,7 @@ export default function useRoleplaySession() {
     setSummaryTab,
     evaluating,
     bottomRef,
+    sessionInfo, // sessionId 포함
     
     // 입력 모드 상태
     isKeyboardMode,

--- a/src/features/roleplay/summary/components/SummaryView.jsx
+++ b/src/features/roleplay/summary/components/SummaryView.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import {
   Stack,
   Card,
@@ -8,9 +8,14 @@ import {
   IconButton,
   Divider,
   Collapse,
-  Button
+  Button,
+  CircularProgress,
+  Alert,
+  Chip
 } from '@mui/material'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import { getComprehensiveFeedback } from '../../../../services/roleplayService'
+import LoadingSpinner from '../../../../components/Common/LoadingSpinner'
 
 const normalizeConversationMessages = (rawMessages = []) => {
   if (!Array.isArray(rawMessages)) return []
@@ -30,17 +35,97 @@ const normalizeConversationMessages = (rawMessages = []) => {
 export default function SummaryView({
   messages,
   onClose,
-  scenarioTitle = '롤플레잉 시나리오'
+  scenarioTitle = '롤플레잉 시나리오',
+  sessionId = null
 }) {
   const [isConversationOpen, setIsConversationOpen] = React.useState(true)
   const [isLongOpen, setIsLongOpen] = React.useState(false)
+  const [feedback, setFeedback] = useState(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
 
   const normalizedMessages = normalizeConversationMessages(messages)
   const displayMessages = normalizedMessages.length > 0 ? normalizedMessages : MOCK_CONVERSATION
 
-  const SHORT_FEEDBACK = '짧은 종합 피드백 더미: 이번 대화에서 핵심 의도를 잘 전달했고 흐름이 자연스러웠습니다.'
-  const LONG_FEEDBACK =
-    '긴 종합 피드백 더미: 이번 롤플레잉에서는 상황 이해와 맥락 유지가 전반적으로 우수했습니다. 다만 몇 차례 문법적 어색함이 있었고, 특정 질문에 답변이 길어졌습니다. 다음 연습에서는 핵심 메시지를 간결하게 전달하고, 일정한 발음과 억양을 유지해 보세요.'
+  // 종합 피드백 조회 (피드백 생성 완료까지 대기)
+  useEffect(() => {
+    if (!sessionId) {
+      console.warn('[SummaryView] sessionId가 없어 피드백을 조회할 수 없습니다.')
+      return
+    }
+
+    let pollCount = 0
+    const MAX_POLLS = 20 // 최대 20번 폴링 (약 40초)
+    const POLL_INTERVAL = 2000 // 2초마다 조회
+
+    const pollFeedback = async () => {
+      setLoading(true)
+      setError(null)
+      
+      const tryPoll = async () => {
+        try {
+          const feedbackData = await getComprehensiveFeedback(sessionId)
+          console.log('[SummaryView] 피드백 응답 데이터:', feedbackData)
+          console.log('[SummaryView] 피드백 필드 확인:', {
+            avgPronunciation: feedbackData?.avgPronunciation,
+            avgPronunciaition: feedbackData?.avgPronunciaition,
+            avgGrammar: feedbackData?.avgGrammar,
+            avgRelevance: feedbackData?.avgRelevance,
+            feedbackShort: feedbackData?.feedbackShort,
+            feedback_short: feedbackData?.feedback_short,
+            feedbackLong: feedbackData?.feedbackLong,
+            feedback_long: feedbackData?.feedback_long
+          })
+          setFeedback(feedbackData)
+          setLoading(false)
+        } catch (err) {
+          // 404 에러면 피드백이 아직 생성 중이므로 계속 폴링
+          if (err.response?.status === 404 && pollCount < MAX_POLLS) {
+            pollCount++
+            setTimeout(tryPoll, POLL_INTERVAL)
+          } else {
+            console.error('[SummaryView] 피드백 조회 실패:', err)
+            setError('피드백을 불러오는 중 오류가 발생했습니다.')
+            setLoading(false)
+          }
+        }
+      }
+
+      tryPoll()
+    }
+
+    pollFeedback()
+  }, [sessionId])
+
+  // 피드백 데이터 (API 응답 또는 기본값)
+  const avgPronunciation = feedback?.avgPronunciation ?? feedback?.avgPronunciaition ?? feedback?.avg_pronunciation ?? feedback?.avg_pronunciaition ?? null
+  const avgGrammar = feedback?.avgGrammar ?? feedback?.avg_grammar ?? null
+  const avgRelevance = feedback?.avgRelevance ?? feedback?.avg_relevance ?? null
+  const shortFeedback = feedback?.feedbackShort ?? feedback?.feedback_short ?? ''
+  const longFeedback = feedback?.feedbackLong ?? feedback?.feedback_long ?? ''
+
+  // 로딩 중이거나 피드백이 없으면 전체 페이지 대신 로딩 스피너만 표시
+  if (loading || !feedback) {
+    return (
+      <Box sx={{ py: { xs: 2, sm: 3 }, px: { xs: 0, sm: 0 }, minHeight: '60vh', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <LoadingSpinner message="종합 피드백을 생성하고 있습니다..." />
+      </Box>
+    )
+  }
+
+  // 에러가 있으면 에러 메시지 표시
+  if (error) {
+    return (
+      <Box sx={{ py: { xs: 2, sm: 3 }, px: { xs: 0, sm: 0 } }}>
+        <Alert severity="warning" sx={{ mb: 1 }}>
+          {error}
+        </Alert>
+        <Button variant="outlined" onClick={onClose} sx={{ mt: 2 }}>
+          닫기
+        </Button>
+      </Box>
+    )
+  }
 
   return (
     <Box sx={{ py: { xs: 2, sm: 3 }, px: { xs: 0, sm: 0 } }}>
@@ -60,47 +145,96 @@ export default function SummaryView({
 
         {/* 종합 피드백 */}
         <Card
-          variant="outlined"
-          sx={{
-            borderRadius: 3,
-            border: '1px solid rgba(124,108,255,0.2)',
-            background: 'linear-gradient(135deg, rgba(124,108,255,0.04) 0%, rgba(75,60,248,0.02) 100%)',
-            boxShadow: '0 8px 24px rgba(124,108,255,0.12)'
-          }}
-        >
-          <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-            <Box>
-              <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.5 }}>
-                짧은 버전
-              </Typography>
-              <Typography variant="body2" color="text.primary">
-                {SHORT_FEEDBACK}
-              </Typography>
-            </Box>
+            variant="outlined"
+            sx={{
+              borderRadius: 3,
+              border: '1px solid rgba(124,108,255,0.2)',
+              background: 'linear-gradient(135deg, rgba(124,108,255,0.04) 0%, rgba(75,60,248,0.02) 100%)',
+              boxShadow: '0 8px 24px rgba(124,108,255,0.12)'
+            }}
+          >
+            <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+              {/* 점수 표시 */}
+              {(avgPronunciation !== null || avgGrammar !== null || avgRelevance !== null) && (
+                <>
+                  <Box>
+                    <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 1 }}>
+                      평균 점수
+                    </Typography>
+                    <Stack direction="row" spacing={1} flexWrap="wrap" gap={1}>
+                      {avgPronunciation !== null && (
+                        <Chip
+                          label={`발음: ${avgPronunciation}점`}
+                          size="small"
+                          sx={{
+                            bgcolor: 'rgba(124,108,255,0.1)',
+                            color: 'primary.main',
+                            fontWeight: 600
+                          }}
+                        />
+                      )}
+                      {avgGrammar !== null && (
+                        <Chip
+                          label={`문법: ${avgGrammar}점`}
+                          size="small"
+                          sx={{
+                            bgcolor: 'rgba(124,108,255,0.1)',
+                            color: 'primary.main',
+                            fontWeight: 600
+                          }}
+                        />
+                      )}
+                      {avgRelevance !== null && (
+                        <Chip
+                          label={`관련성: ${avgRelevance}점`}
+                          size="small"
+                          sx={{
+                            bgcolor: 'rgba(124,108,255,0.1)',
+                            color: 'primary.main',
+                            fontWeight: 600
+                          }}
+                        />
+                      )}
+                    </Stack>
+                  </Box>
+                  <Divider />
+                </>
+              )}
 
-            <Divider />
-
-            <Box>
-              <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-                <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
-                  긴 버전
+              {/* 짧은 피드백 */}
+              <Box>
+                <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.5 }}>
+                  짧은 버전
                 </Typography>
-                <IconButton
-                  size="small"
-                  onClick={() => setIsLongOpen((prev) => !prev)}
-                  sx={{ transform: isLongOpen ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 0.2s ease' }}
-                >
-                  <ExpandMoreIcon fontSize="small" />
-                </IconButton>
+                <Typography variant="body2" color="text.primary">
+                  {shortFeedback}
+                </Typography>
               </Box>
-              <Collapse in={isLongOpen} timeout="auto" unmountOnExit>
-                <Typography variant="body2" color="text.primary" sx={{ mt: 1 }}>
-                  {LONG_FEEDBACK}
-                </Typography>
-              </Collapse>
-            </Box>
-          </CardContent>
-        </Card>
+
+              <Divider />
+
+              {/* 긴 피드백 */}
+              <Box>
+                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                  <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
+                    긴 버전
+                  </Typography>
+                  <IconButton
+                    size="small"
+                    onClick={() => setIsLongOpen((prev) => !prev)}
+                    sx={{ transform: isLongOpen ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 0.2s ease' }}
+                  >
+                    <ExpandMoreIcon fontSize="small" />
+                  </IconButton>
+                </Box>
+                <Collapse in={isLongOpen} timeout="auto" unmountOnExit>
+                  <Typography variant="body2" color="text.primary" sx={{ mt: 1, whiteSpace: 'pre-wrap' }}>
+                    {longFeedback}
+                  </Typography>
+                </Collapse>
+              </Box>
+            </CardContent>
+          </Card>
 
         {/* 대화 로그 */}
         <Box>

--- a/src/services/httpClient.js
+++ b/src/services/httpClient.js
@@ -60,8 +60,15 @@ export async function request(url, options = {}) {
       return await response.json()
     }
 
-    // JSON이 아니면 텍스트로 반환
-    return await response.text()
+    // Content-Type이 없거나 JSON이 아니면 텍스트로 받아서 JSON 파싱 시도
+    const text = await response.text()
+    try {
+      // 텍스트가 JSON 형식이면 파싱
+      return JSON.parse(text)
+    } catch {
+      // JSON이 아니면 텍스트 그대로 반환
+      return text
+    }
   } catch (error) {
     // 네트워크 에러 처리
     if (error.message.includes('Failed to fetch') || error.message.includes('NetworkError')) {
@@ -93,7 +100,10 @@ async function handleErrorResponse(response) {
     }
   }
 
-  throw new Error(errorMessage)
+  const error = new Error(errorMessage)
+  // response 객체를 에러에 포함시켜서 상태 코드를 확인할 수 있도록 함
+  error.response = response
+  throw error
 }
 
 /**

--- a/src/services/roleplayService.js
+++ b/src/services/roleplayService.js
@@ -74,6 +74,24 @@ export async function startSession(scenarioId, interactionMode = 'default') {
 }
 
 /**
+ * 종합 피드백 조회
+ * Gateway를 통해 Spring2로 프록시
+ * @param {string} sessionId - 세션 ID
+ * @returns {Promise<Object>} 종합 피드백 데이터
+ *   {
+ *     avgPronunciaition: number,
+ *     avgGrammar: number,
+ *     avgRelevance: number,
+ *     feedbackShort: string,
+ *     feedbackLong: string
+ *   }
+ */
+export async function getComprehensiveFeedback(sessionId) {
+  const url = `${API_ENDPOINTS.GATEWAY}/feedback/comprehensive/${sessionId}`
+  return httpClient.get(url)
+}
+
+/**
  * WebSocket 연결 생성
  * @param {string} wsUrl - WebSocket URL
  * @param {Function} onMessage - 메시지 수신 핸들러

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -11,21 +11,15 @@
 
 import * as httpClient from './httpClient'
 import { API_ENDPOINTS } from '../config/constants'
-import { getUserIdFromToken } from '../utils/jwt'
 
 /**
  * 현재 로그인한 사용자 정보 조회
  * @returns {Promise<Object>} 사용자 정보 (userId, email, name, jobRole 등)
  */
 export async function getCurrentUser() {
-  const userId = getUserIdFromToken()
-  if (!userId) {
-    throw new Error('로그인이 필요합니다.')
-  }
-
-  // Spring2의 /internal/users/{userId} 엔드포인트 호출
-  // Vite proxy를 통해 /api/spring2로 요청하면 Spring2로 프록시됨
-  const url = `/api/spring2/internal/users/${userId}`
+  // Gateway의 /users/me 엔드포인트 호출
+  // Gateway가 JWT에서 userId를 추출하여 Spring2로 요청
+  const url = `${API_ENDPOINTS.GATEWAY}/users/me`
   return httpClient.get(url)
 }
 


### PR DESCRIPTION
## 🧩 개요
롤플레잉 세션 종료 후 종합 피드백을 조회하여 SummaryView에 표시하는 기능을 구현했습니다.

## 🔗 관련 이슈
Closes #

## 🌿 브랜치 정보
- 브랜치 이름: `feature/<이슈번호>-<작업내용>` 또는 `fix/<이슈번호>-<수정내용>`
- 기준 브랜치: `develop`

> 브랜치 이름 규칙이 맞지 않으면 리뷰 요청 전에 수정해주세요.

## ✅ 변경 사항
- [ ] SummaryView에서 종합 피드백 API 연동 (폴링 방식)
- [ ] httpClient 에러 응답 처리 개선 (response 객체 첨부)
- [ ] roleplayService에 getComprehensiveFeedback 함수 추가
- [ ] 피드백 로딩 중 전체 페이지 스피너 표시
- [ ] 404 에러 시 재시도 로직 구현

## 🧪 테스트
- 종합 피드백이 DB에 저장된 후 SummaryView에서 정상적으로 표시되는지 확인
- 피드백 생성 중일 때 로딩 스피너가 표시되는지 확인
- 404 에러 발생 시 재시도가 정상적으로 동작하는지 확인


## 📸 참고 자료
(선택) 스크린샷, 로그 등

---

> 💡 **PR 생성 시 “Closes #이슈번호”를 포함하면**  
> 병합 시 해당 이슈가 자동으로 닫힙니다.
