### PR TITLE
feat: ElevenLabs로 TTS API 변경

### DIFF
--- a/src/components/Common/ErrorBoundary.jsx
+++ b/src/components/Common/ErrorBoundary.jsx
@@ -114,3 +114,4 @@ export default ErrorBoundary
 
 
 
+

--- a/src/components/Common/LoadingSpinner.jsx
+++ b/src/components/Common/LoadingSpinner.jsx
@@ -42,3 +42,4 @@ export default function LoadingSpinner({ message = '로딩 중...' }) {
 
 
 
+

--- a/src/components/Route/ProtectedRoute.jsx
+++ b/src/components/Route/ProtectedRoute.jsx
@@ -34,3 +34,4 @@ export default function ProtectedRoute({ children }) {
 
 
 
+

--- a/src/features/roleplay/pages/RoleplayPage.jsx
+++ b/src/features/roleplay/pages/RoleplayPage.jsx
@@ -138,6 +138,8 @@ export default function RoleplayPage() {
           onSendMessage={session.sendMessage}
           isTTSPlaying={session.isTTSPlaying}
           onAvatarLoad={session.handleAvatarLoad}
+          visemeQueue={session.visemeQueue}
+          audioRef={session.audioRef}
         />
         {openEnd && (
           <Suspense fallback={null}>

--- a/src/features/roleplay/session/components/AvatarWindow.jsx
+++ b/src/features/roleplay/session/components/AvatarWindow.jsx
@@ -7,7 +7,7 @@ import { OrbitControls, useGLTF, useAnimations, Environment, PresentationControl
 const DEFAULT_AVATAR_URL = 'https://models.readyplayer.me/693a22fa100ae875d553c198.glb'
 
 // 아바타 모델 컴포넌트
-function AvatarModel({ url, onLoad, onError, isTTSPlaying = false, visemeQueue = [], audioRef = null }) {
+function AvatarModel({ url, onLoad, onError, isTTSPlaying = false, visemeQueue = null, audioRef = null }) {
   const groupRef = useRef()
   const { scene, animations } = useGLTF(url)
   const { actions, mixer } = useAnimations(animations, groupRef)
@@ -34,12 +34,15 @@ function AvatarModel({ url, onLoad, onError, isTTSPlaying = false, visemeQueue =
     // ElevenLabs Viseme 데이터로 입 모양 제어 (부드러운 전환)
     const LERP_SPEED = 8.0 // 전환 속도 (높을수록 빠름, 낮을수록 부드러움)
     
-    if (isTTSPlaying && visemeQueue.length > 0 && mouthTargetsRef.current.length > 0 && audioRef?.current) {
+    // visemeQueue는 useRef로 관리되므로 .current로 접근
+    const queue = visemeQueue?.current || []
+    
+    if (isTTSPlaying && queue.length > 0 && mouthTargetsRef.current.length > 0 && audioRef?.current) {
       // 오디오 재생 시간 가져오기
       const currentTime = audioRef.current.currentTime || 0
       
       // 현재 시간에 해당하는 Viseme 찾기
-      const currentViseme = visemeQueue.find(v => 
+      const currentViseme = queue.find(v => 
         currentTime >= v.startTime && currentTime <= v.endTime
       )
       
@@ -146,7 +149,7 @@ function AvatarModel({ url, onLoad, onError, isTTSPlaying = false, visemeQueue =
 }
 
 // Three.js Canvas 래퍼
-function AvatarCanvas({ avatarUrl, onLoad, onError, isTTSPlaying, visemeQueue = [], audioRef = null }) {
+function AvatarCanvas({ avatarUrl, onLoad, onError, isTTSPlaying, visemeQueue = null, audioRef = null }) {
   return (
     <Canvas
       camera={{ position: [0, 0, 3.5], fov: 50 }}
@@ -199,7 +202,7 @@ function AvatarCanvas({ avatarUrl, onLoad, onError, isTTSPlaying, visemeQueue = 
   )
 }
 
-export default function AvatarWindow({ avatarUrl, aiRoleName = 'AI', isTTSPlaying = false, onAvatarLoad, visemeQueue = [], audioRef = null }) {
+export default function AvatarWindow({ avatarUrl, aiRoleName = 'AI', isTTSPlaying = false, onAvatarLoad, visemeQueue = null, audioRef = null }) {
   const containerRef = useRef(null)
   const [isLoading, setIsLoading] = useState(true)
   const [loadError, setLoadError] = useState(null)

--- a/src/features/roleplay/session/components/AvatarWindow.jsx
+++ b/src/features/roleplay/session/components/AvatarWindow.jsx
@@ -4,14 +4,15 @@ import { Fullscreen, FullscreenExit } from '@mui/icons-material'
 import { Canvas, useFrame } from '@react-three/fiber'
 import { OrbitControls, useGLTF, useAnimations, Environment, PresentationControls } from '@react-three/drei'
 
-const DEFAULT_AVATAR_URL = 'https://models.readyplayer.me/6923c7a27b7a88e1f6a5ed6a.glb'
+const DEFAULT_AVATAR_URL = 'https://models.readyplayer.me/693a22fa100ae875d553c198.glb'
 
 // 아바타 모델 컴포넌트
-function AvatarModel({ url, onLoad, onError, isTTSPlaying = false }) {
+function AvatarModel({ url, onLoad, onError, isTTSPlaying = false, visemeQueue = [], audioRef = null }) {
   const groupRef = useRef()
   const { scene, animations } = useGLTF(url)
   const { actions, mixer } = useAnimations(animations, groupRef)
   const mouthTargetsRef = useRef([]) // 입 morph target 참조
+  const currentMouthValueRef = useRef(0) // 현재 입 모양 값 (부드러운 전환을 위해)
   
   // 아바타 위치 설정 (x: 좌우, y: 상하, z: 앞뒤)
   // 이 값들을 변경하여 아바타 위치를 조정하세요
@@ -30,22 +31,44 @@ function AvatarModel({ url, onLoad, onError, isTTSPlaying = false }) {
       // groupRef.current.rotation.y += delta * 0.1
     }
     
-    // TTS 재생 중 입 모양 애니메이션 (빠르고 크게)
-    if (isTTSPlaying && mouthTargetsRef.current.length > 0) {
-      // 빠른 속도로 입 벌리기 (sin 파형 사용, 빠르게)
-      const speed = 8 // 빠른 속도
-      const mouthValue = Math.abs(Math.sin(state.clock.elapsedTime * speed)) * 0.9 + 0.1 // 0.1 ~ 1.0
+    // ElevenLabs Viseme 데이터로 입 모양 제어 (부드러운 전환)
+    const LERP_SPEED = 8.0 // 전환 속도 (높을수록 빠름, 낮을수록 부드러움)
+    
+    if (isTTSPlaying && visemeQueue.length > 0 && mouthTargetsRef.current.length > 0 && audioRef?.current) {
+      // 오디오 재생 시간 가져오기
+      const currentTime = audioRef.current.currentTime || 0
       
+      // 현재 시간에 해당하는 Viseme 찾기
+      const currentViseme = visemeQueue.find(v => 
+        currentTime >= v.startTime && currentTime <= v.endTime
+      )
+      
+      // 목표 입 모양 값 결정
+      let targetMouthValue = 0
+      if (currentViseme) {
+        targetMouthValue = currentViseme.value
+      }
+      
+      // 부드러운 전환 (Lerp: Linear Interpolation)
+      const currentValue = currentMouthValueRef.current
+      const lerpValue = currentValue + (targetMouthValue - currentValue) * Math.min(delta * LERP_SPEED, 1.0)
+      currentMouthValueRef.current = lerpValue
+      
+      // 적용
       mouthTargetsRef.current.forEach(({ mesh, index }) => {
         if (mesh.morphTargetInfluences && mesh.morphTargetInfluences[index] !== undefined) {
-          mesh.morphTargetInfluences[index] = mouthValue
+          mesh.morphTargetInfluences[index] = lerpValue
         }
       })
     } else {
-      // TTS 재생 중지 시 입 닫기
+      // TTS 재생 중지 시 입 닫기 (부드럽게)
+      const currentValue = currentMouthValueRef.current
+      const lerpValue = currentValue + (0 - currentValue) * Math.min(delta * LERP_SPEED, 1.0)
+      currentMouthValueRef.current = lerpValue
+      
       mouthTargetsRef.current.forEach(({ mesh, index }) => {
         if (mesh.morphTargetInfluences && mesh.morphTargetInfluences[index] !== undefined) {
-          mesh.morphTargetInfluences[index] = 0
+          mesh.morphTargetInfluences[index] = lerpValue
         }
       })
     }
@@ -123,7 +146,7 @@ function AvatarModel({ url, onLoad, onError, isTTSPlaying = false }) {
 }
 
 // Three.js Canvas 래퍼
-function AvatarCanvas({ avatarUrl, onLoad, onError, isTTSPlaying }) {
+function AvatarCanvas({ avatarUrl, onLoad, onError, isTTSPlaying, visemeQueue = [], audioRef = null }) {
   return (
     <Canvas
       camera={{ position: [0, 0, 3.5], fov: 50 }}
@@ -152,6 +175,8 @@ function AvatarCanvas({ avatarUrl, onLoad, onError, isTTSPlaying }) {
           onLoad={onLoad}
           onError={onError}
           isTTSPlaying={isTTSPlaying}
+          visemeQueue={visemeQueue}
+          audioRef={audioRef}
         />
       </Suspense>
 
@@ -174,7 +199,7 @@ function AvatarCanvas({ avatarUrl, onLoad, onError, isTTSPlaying }) {
   )
 }
 
-export default function AvatarWindow({ avatarUrl, aiRoleName = 'AI', isTTSPlaying = false, onAvatarLoad }) {
+export default function AvatarWindow({ avatarUrl, aiRoleName = 'AI', isTTSPlaying = false, onAvatarLoad, visemeQueue = [], audioRef = null }) {
   const containerRef = useRef(null)
   const [isLoading, setIsLoading] = useState(true)
   const [loadError, setLoadError] = useState(null)
@@ -284,11 +309,13 @@ export default function AvatarWindow({ avatarUrl, aiRoleName = 'AI', isTTSPlayin
           }}
         >
           {!loadError ? (
-            <AvatarCanvas 
-              avatarUrl={avatarUrl || DEFAULT_AVATAR_URL} 
+            <AvatarCanvas
+              avatarUrl={avatarUrl || DEFAULT_AVATAR_URL}
               onLoad={handleAvatarLoad}
               onError={handleAvatarError}
               isTTSPlaying={isTTSPlaying}
+              visemeQueue={visemeQueue}
+              audioRef={audioRef}
             />
           ) : (
             <Box

--- a/src/features/roleplay/session/components/SessionView.jsx
+++ b/src/features/roleplay/session/components/SessionView.jsx
@@ -20,7 +20,7 @@ export default function SessionView({
   onSendMessage,
   isTTSPlaying = false,
   onAvatarLoad = () => {},
-  visemeQueue = [],
+  visemeQueue = null,
   audioRef = null
 }) {
   return (

--- a/src/features/roleplay/session/components/SessionView.jsx
+++ b/src/features/roleplay/session/components/SessionView.jsx
@@ -19,7 +19,9 @@ export default function SessionView({
   onTextInputChange,
   onSendMessage,
   isTTSPlaying = false,
-  onAvatarLoad = () => {}
+  onAvatarLoad = () => {},
+  visemeQueue = [],
+  audioRef = null
 }) {
   return (
     <Box
@@ -34,7 +36,12 @@ export default function SessionView({
       }}
     >
       <SessionHeader title={selectedTitle} onEndSession={onEndSession} />
-      <AvatarWindow isTTSPlaying={isTTSPlaying} onAvatarLoad={onAvatarLoad} />
+      <AvatarWindow 
+        isTTSPlaying={isTTSPlaying} 
+        onAvatarLoad={onAvatarLoad}
+        visemeQueue={visemeQueue}
+        audioRef={audioRef}
+      />
       <MessageList messages={messages} bottomRef={bottomRef} />
       
       {isKeyboardMode ? (

--- a/src/features/roleplay/session/hooks/useRoleplaySession.js
+++ b/src/features/roleplay/session/hooks/useRoleplaySession.js
@@ -88,7 +88,7 @@ export default function useRoleplaySession() {
   const [isInitialized, setIsInitialized] = useState(false)
   const [isTTSPlaying, setIsTTSPlaying] = useState(false)
   const [isAvatarLoaded, setIsAvatarLoaded] = useState(false)
-  const [visemeQueue, setVisemeQueue] = useState([])
+  const visemeQueue = useRef([]) // 성능 최적화: 리렌더링 없이 데이터 관리
 
   // ========================================
   // Ref 정의
@@ -256,7 +256,7 @@ export default function useRoleplaySession() {
     clearLipSyncDelay()
     clearLipSyncEnd()
     setIsTTSPlaying(false)
-    setVisemeQueue([]) // Viseme 큐 초기화
+    visemeQueue.current = [] // Viseme 큐 초기화
   }
 
   /**
@@ -269,7 +269,7 @@ export default function useRoleplaySession() {
         audioRef.current.pause()
         audioRef.current = null
       }
-      setVisemeQueue([]) // Viseme 큐 초기화
+      visemeQueue.current = [] // Viseme 큐 초기화
       setIsTTSPlaying(false)
 
       // Base64 디코딩
@@ -288,7 +288,7 @@ export default function useRoleplaySession() {
       audio.onended = () => {
         setIsTTSPlaying(false)
         URL.revokeObjectURL(audioUrl)
-        setVisemeQueue([]) // Viseme 큐 초기화
+        visemeQueue.current = [] // Viseme 큐 초기화
         audioRef.current = null
       }
       
@@ -296,7 +296,7 @@ export default function useRoleplaySession() {
         console.error('[TTS] 오디오 재생 실패:', error)
         setIsTTSPlaying(false)
         URL.revokeObjectURL(audioUrl)
-        setVisemeQueue([])
+        visemeQueue.current = []
         audioRef.current = null
       }
       
@@ -309,19 +309,20 @@ export default function useRoleplaySession() {
     } catch (error) {
       console.error('[TTS] 오디오 처리 실패:', error)
       setIsTTSPlaying(false)
-      setVisemeQueue([])
+      visemeQueue.current = []
     }
   }
 
   /**
    * TTS Viseme 데이터 수신 (ElevenLabs)
+   * 성능 최적화: useRef 사용으로 리렌더링 없이 데이터 관리
    */
   const handleTTSViseme = (visemeData) => {
-    setVisemeQueue(prev => [...prev, {
+    visemeQueue.current.push({
       startTime: visemeData.start_time,
       endTime: visemeData.end_time,
       value: visemeData.value
-    }])
+    })
   }
 
   // ========================================

--- a/src/features/roleplay/session/hooks/useRoleplaySession.js
+++ b/src/features/roleplay/session/hooks/useRoleplaySession.js
@@ -88,6 +88,7 @@ export default function useRoleplaySession() {
   const [isInitialized, setIsInitialized] = useState(false)
   const [isTTSPlaying, setIsTTSPlaying] = useState(false)
   const [isAvatarLoaded, setIsAvatarLoaded] = useState(false)
+  const [visemeQueue, setVisemeQueue] = useState([])
 
   // ========================================
   // Ref 정의
@@ -98,6 +99,7 @@ export default function useRoleplaySession() {
   const streamingTimeoutRef = useRef(null)
   const aiTypingTimeoutRef = useRef(null)
   const currentUtteranceRef = useRef(null)
+  const audioRef = useRef(null)
   const mediaRecorderRef = useRef(null)
   const audioStreamRef = useRef(null)
   const sttPartialTextRef = useRef('')
@@ -228,83 +230,98 @@ export default function useRoleplaySession() {
 
   /**
    * TTS (Text-to-Speech) 함수
+   * ElevenLabs TTS로 대체되었으므로 비활성화
+   * WebSocket을 통해 TTS_AUDIO 메시지로 처리됨
    */
   const speakText = (text) => {
-    setTimeout(() => {
-      try {
-        if (currentUtteranceRef.current) {
-          window.speechSynthesis.cancel()
-          currentUtteranceRef.current = null
-        }
-        clearLipSyncDelay()
-        clearLipSyncEnd()
-        setIsTTSPlaying(false)
-
-        if (!text || text.trim().length === 0) {
-          return
-        }
-
-        if (!('speechSynthesis' in window)) {
-          return
-        }
-
-        const utterance = new SpeechSynthesisUtterance(text)
-        utterance.lang = TTS_CONFIG.lang
-        utterance.rate = TTS_CONFIG.rate
-        utterance.pitch = TTS_CONFIG.pitch
-        utterance.volume = TTS_CONFIG.volume
-
-        const voices = window.speechSynthesis.getVoices()
-        const englishVoice = voices.find(voice => 
-          voice.lang.startsWith('en') && voice.name.includes('English')
-        ) || voices.find(voice => voice.lang.startsWith('en'))
-        
-        if (englishVoice) {
-          utterance.voice = englishVoice
-        }
-
-        utterance.onstart = () => {
-          clearLipSyncDelay()
-          lipSyncDelayTimeoutRef.current = setTimeout(() => {
-            setIsTTSPlaying(true)
-            scheduleLipSyncEnd(text)
-            lipSyncDelayTimeoutRef.current = null
-          }, LIP_SYNC_DELAY_MS)
-        }
-
-        utterance.onend = () => {
-          currentUtteranceRef.current = null
-          clearLipSyncDelay()
-          clearLipSyncEnd()
-          setIsTTSPlaying(false)
-        }
-
-        utterance.onerror = () => {
-          currentUtteranceRef.current = null
-          clearLipSyncDelay()
-          clearLipSyncEnd()
-          setIsTTSPlaying(false)
-        }
-
-        currentUtteranceRef.current = utterance
-        window.speechSynthesis.speak(utterance)
-      } catch (error) {
-        currentUtteranceRef.current = null
-      }
-    }, 0)
+    // Web Speech API 비활성화 - ElevenLabs TTS 사용
+    return
   }
 
   /**
    * TTS 중단
    */
   const stopTTS = () => {
+    // Web Speech API 중단
     if (currentUtteranceRef.current) {
       window.speechSynthesis.cancel()
       currentUtteranceRef.current = null
     }
+    // ElevenLabs TTS 오디오 중단
+    if (audioRef.current) {
+      audioRef.current.pause()
+      audioRef.current.currentTime = 0
+      audioRef.current = null
+    }
     clearLipSyncDelay()
     clearLipSyncEnd()
     setIsTTSPlaying(false)
+    setVisemeQueue([]) // Viseme 큐 초기화
+  }
+
+  /**
+   * TTS 오디오 재생 (ElevenLabs)
+   */
+  const handleTTSAudio = (audioBase64) => {
+    try {
+      // 이전 오디오 중지 및 정리
+      if (audioRef.current) {
+        audioRef.current.pause()
+        audioRef.current = null
+      }
+      setVisemeQueue([]) // Viseme 큐 초기화
+      setIsTTSPlaying(false)
+
+      // Base64 디코딩
+      const audioData = Uint8Array.from(atob(audioBase64), c => c.charCodeAt(0))
+      const blob = new Blob([audioData], { type: 'audio/mpeg' })
+      const audioUrl = URL.createObjectURL(blob)
+      
+      // 오디오 재생
+      const audio = new Audio(audioUrl)
+      audioRef.current = audio
+      
+      audio.onplay = () => {
+        setIsTTSPlaying(true)
+      }
+      
+      audio.onended = () => {
+        setIsTTSPlaying(false)
+        URL.revokeObjectURL(audioUrl)
+        setVisemeQueue([]) // Viseme 큐 초기화
+        audioRef.current = null
+      }
+      
+      audio.onerror = (error) => {
+        console.error('[TTS] 오디오 재생 실패:', error)
+        setIsTTSPlaying(false)
+        URL.revokeObjectURL(audioUrl)
+        setVisemeQueue([])
+        audioRef.current = null
+      }
+      
+      audio.play().catch(error => {
+        console.error('[TTS] 오디오 재생 시작 실패:', error)
+        setIsTTSPlaying(false)
+        URL.revokeObjectURL(audioUrl)
+        audioRef.current = null
+      })
+    } catch (error) {
+      console.error('[TTS] 오디오 처리 실패:', error)
+      setIsTTSPlaying(false)
+      setVisemeQueue([])
+    }
+  }
+
+  /**
+   * TTS Viseme 데이터 수신 (ElevenLabs)
+   */
+  const handleTTSViseme = (visemeData) => {
+    setVisemeQueue(prev => [...prev, {
+      startTime: visemeData.start_time,
+      endTime: visemeData.end_time,
+      value: visemeData.value
+    }])
   }
 
   // ========================================
@@ -696,6 +713,16 @@ export default function useRoleplaySession() {
         break
       case 'FEEDBACK_STREAMING':
         handleFeedbackStreaming(message)
+        break
+      case 'TTS_AUDIO':
+        handleTTSAudio(message.audio_base64)
+        break
+      case 'TTS_VISEME':
+        handleTTSViseme({
+          start_time: message.start_time,
+          end_time: message.end_time,
+          value: message.value
+        })
         break
       case 'ERROR':
         handleError(message)
@@ -1208,6 +1235,8 @@ export default function useRoleplaySession() {
     // TTS 및 아바타 상태
     isTTSPlaying,
     isAvatarLoaded,
-    handleAvatarLoad
+    handleAvatarLoad,
+    visemeQueue,
+    audioRef
   }
 }


### PR DESCRIPTION
## 🧩 개요
Web Speech API TTS를 ElevenLabs TTS로 교체하고 립싱크 기능을 추가했습니다.

## 🔗 관련 이슈
Closes #

## 🌿 브랜치 정보
- 브랜치 이름: `feature/<이슈번호>-<작업내용>` 또는 `fix/<이슈번호>-<수정내용>`
- 기준 브랜치: `develop`

> 브랜치 이름 규칙이 맞지 않으면 리뷰 요청 전에 수정해주세요.

## ✅ 변경 사항
- [ ] ElevenLabs TTS 통합 (WebSocket으로 오디오/Viseme 데이터 수신
- [ ] 립싱크 기능 구현 (Viseme 데이터 기반 입 모양 애니메이션)
- [ ] Web Speech API TTS 비활성화

## 🧪 테스트
롤플레잉 실행 시 AI 질문에 ElevenLabs TTS 오디오 재생 확인
아바타 입 모양이 오디오와 동기화되어 움직이는지 확인
브라우저 콘솔 및 Network 탭에서 TTS_AUDIO, TTS_VISEME 메시지 수신 확인

## 📸 참고 자료
(선택) 스크린샷, 로그 등

---

> 💡 **PR 생성 시 “Closes #이슈번호”를 포함하면**  
> 병합 시 해당 이슈가 자동으로 닫힙니다.
