### PR TITLE
fix: Slack/Prompt 시나리오의 나의 역할 표시 오류 수정

### DIFF
--- a/src/features/roleplay/scenario-list/components/CreateRoleplayDialog.jsx
+++ b/src/features/roleplay/scenario-list/components/CreateRoleplayDialog.jsx
@@ -56,7 +56,8 @@ export default function CreateRoleplayDialog({
           color: '#212121',
           pb: 1,
           pt: 3.5,
-          px: 3
+          px: 3,
+          textAlign: 'center'
         }}
       >
         롤플레이 만들기
@@ -75,14 +76,14 @@ export default function CreateRoleplayDialog({
                 gap: 0.5
               }}
             >
-              AI 역할
+              나의 역할
             </Typography>
             <TextField
               fullWidth
               variant="outlined"
-              value={aiRole}
-              onChange={onAiRoleChange}
-              placeholder="예: Project Manager"
+              value={myRole}
+              onChange={onMyRoleChange}
+              placeholder="예: Software Engineer"
               sx={{
                 '& .MuiOutlinedInput-root': {
                   backgroundColor: '#FFFFFF',
@@ -127,14 +128,14 @@ export default function CreateRoleplayDialog({
                 gap: 0.5
               }}
             >
-              나의 역할
+            AI 역할
             </Typography>
             <TextField
               fullWidth
               variant="outlined"
-              value={myRole}
-              onChange={onMyRoleChange}
-              placeholder="예: Software Engineer"
+              value={aiRole}
+              onChange={onAiRoleChange}
+              placeholder="예: Project Manager"
               sx={{
                 '& .MuiOutlinedInput-root': {
                   backgroundColor: '#FFFFFF',

--- a/src/features/roleplay/scenario-list/components/ScenarioList.jsx
+++ b/src/features/roleplay/scenario-list/components/ScenarioList.jsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback } from 'react'
+import React, { memo, useCallback, useState } from 'react'
 import {
   Tabs,
   Tab,
@@ -11,7 +11,10 @@ import {
   CircularProgress,
   IconButton,
   Button,
-  Chip
+  Chip,
+  Select,
+  MenuItem,
+  FormControl
 } from '@mui/material'
 import CalendarMonthIcon from '@mui/icons-material/CalendarMonth'
 import PlayArrowIcon from '@mui/icons-material/PlayArrow'
@@ -33,10 +36,33 @@ function ScenarioList({
   onRetry,
   onOpenCalendar
 }) {
+  // Detail 시나리오의 AI 역할 선택 상태 관리
+  const [selectedAiRoleIndices, setSelectedAiRoleIndices] = useState({})
+
   const handleStart = useCallback((item) => {
-    const body = item.description || item.summary || `AI 역할 ${item.aiRole}과의 대화`
-    onStartRoleplay(item.title, body, item.scenarioId || 1)
-  }, [onStartRoleplay])
+    // 그룹화된 Detail 시나리오인 경우, 선택된 AI 역할의 scenarioId 사용
+    let scenarioId = item.scenarioId || 1
+    let aiRole = item.aiRole
+    
+    if (item.isGrouped && item.groupType === 'detail' && item.availableAiRoles) {
+      const selectedIndex = selectedAiRoleIndices[item.scenarioId] ?? item.selectedAiRoleIndex ?? 0
+      const selectedRole = item.availableAiRoles[selectedIndex]
+      if (selectedRole) {
+        scenarioId = selectedRole.scenarioId
+        aiRole = selectedRole.aiRole
+      }
+    }
+    
+    const body = item.description || item.summary || `AI 역할 ${aiRole}과의 대화`
+    onStartRoleplay(item.title, body, scenarioId)
+  }, [onStartRoleplay, selectedAiRoleIndices])
+
+  const handleAiRoleChange = useCallback((scenarioId, index) => {
+    setSelectedAiRoleIndices(prev => ({
+      ...prev,
+      [scenarioId]: index
+    }))
+  }, [])
 
   const scenarioCount = filteredItems.length
 
@@ -132,7 +158,18 @@ function ScenarioList({
         </Box>
       ) : (
         <Stack spacing={2.5}>
-          {filteredItems.map((item, idx) => (
+          {filteredItems.map((item, idx) => {
+            // 그룹화된 Detail 시나리오인 경우, 선택된 AI 역할 정보 가져오기
+            let displayAiRole = item.aiRole
+            if (item.isGrouped && item.groupType === 'detail' && item.availableAiRoles) {
+              const selectedIndex = selectedAiRoleIndices[item.scenarioId] ?? item.selectedAiRoleIndex ?? 0
+              const selectedRole = item.availableAiRoles[selectedIndex]
+              if (selectedRole) {
+                displayAiRole = selectedRole.aiRole
+              }
+            }
+            
+            return (
             <Card 
               key={`${tab}-${item.idx ?? item.scenarioId}`} 
               onClick={() => handleStart(item)}
@@ -171,23 +208,60 @@ function ScenarioList({
             >
               <CardContent sx={{ p: 3 }}>
                 <Stack spacing={2}>
-                  {/* 제목 */}
-                  <Typography 
-                    variant="h6" 
-                    fontWeight={700} 
-                    sx={{ 
-                      fontSize: '1.0625rem',
-                      lineHeight: 1.4,
-                      color: '#212121'
-                    }}
-                  >
-                    {item.title}
-                  </Typography>
+                  {/* 제목 + Overview 배지 */}
+                  <Box sx={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 1 }}>
+                    <Typography 
+                      variant="h6" 
+                      fontWeight={700} 
+                      sx={{ 
+                        fontSize: '1.0625rem',
+                        lineHeight: 1.4,
+                        color: '#212121',
+                        flex: 1
+                      }}
+                    >
+                      {item.title}
+                    </Typography>
+                    {item.isGrouped && item.groupType === 'overview' && (
+                      <Chip
+                        label="Overview"
+                        size="small"
+                        sx={{
+                          height: 24,
+                          fontSize: '0.75rem',
+                          fontWeight: 600,
+                          background: 'linear-gradient(135deg, rgba(124,108,255,0.15) 0%, rgba(75,60,248,0.1) 100%)',
+                          color: 'primary.main',
+                          border: '1px solid rgba(124,108,255,0.3)',
+                          '& .MuiChip-label': {
+                            px: 1.5
+                          }
+                        }}
+                      />
+                    )}
+                    {item.isGrouped && item.groupType === 'detail' && (
+                      <Chip
+                        label="Detail"
+                        size="small"
+                        sx={{
+                          height: 24,
+                          fontSize: '0.75rem',
+                          fontWeight: 600,
+                          background: 'linear-gradient(135deg, rgba(76,175,80,0.15) 0%, rgba(56,142,60,0.1) 100%)',
+                          color: '#4caf50',
+                          border: '1px solid rgba(76,175,80,0.3)',
+                          '& .MuiChip-label': {
+                            px: 1.5
+                          }
+                        }}
+                      />
+                    )}
+                  </Box>
 
                   {/* 역할 정보 그리드 */}
                   <Stack spacing={1.5}>
                     {/* 나의 역할 */}
-                    {userJobRole && (
+                    {item.myRole && (
                       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                         <PersonIcon sx={{ fontSize: 18, color: 'primary.main', opacity: 0.8 }} />
                         <Box>
@@ -195,7 +269,7 @@ function ScenarioList({
                             나의 역할
                           </Typography>
                           <Typography variant="body2" fontWeight={600} color="text.primary">
-                            {userJobRole}
+                            {item.myRole}
                           </Typography>
                         </Box>
                       </Box>
@@ -204,13 +278,46 @@ function ScenarioList({
                     {/* AI 역할 */}
                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                       <SmartToyIcon sx={{ fontSize: 18, color: 'primary.main', opacity: 0.8 }} />
-                      <Box>
+                      <Box sx={{ flex: 1 }}>
                         <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.25 }}>
                           AI 역할
                         </Typography>
-                        <Typography variant="body2" fontWeight={600} color="text.primary">
-                          {item.aiRole || 'AI 역할 미정'}
-                        </Typography>
+                        {item.isGrouped && item.groupType === 'detail' && item.availableAiRoles && item.availableAiRoles.length > 1 ? (
+                          <FormControl size="small" fullWidth sx={{ mt: 0.5 }}>
+                            <Select
+                              value={selectedAiRoleIndices[item.scenarioId] ?? item.selectedAiRoleIndex ?? 0}
+                              onChange={(e) => {
+                                e.stopPropagation() // 카드 클릭 이벤트 방지
+                                handleAiRoleChange(item.scenarioId, e.target.value)
+                              }}
+                              onClick={(e) => e.stopPropagation()} // 카드 클릭 이벤트 방지
+                              sx={{
+                                height: 32,
+                                fontSize: '0.875rem',
+                                fontWeight: 600,
+                                '& .MuiOutlinedInput-notchedOutline': {
+                                  borderColor: 'rgba(124,108,255,0.3)',
+                                },
+                                '&:hover .MuiOutlinedInput-notchedOutline': {
+                                  borderColor: 'primary.main',
+                                },
+                                '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+                                  borderColor: 'primary.main',
+                                },
+                              }}
+                            >
+                              {item.availableAiRoles.map((role, idx) => (
+                                <MenuItem key={idx} value={idx}>
+                                  {role.aiRole}
+                                </MenuItem>
+                              ))}
+                            </Select>
+                          </FormControl>
+                        ) : (
+                          <Typography variant="body2" fontWeight={600} color="text.primary">
+                            {displayAiRole || 'AI 역할 미정'}
+                          </Typography>
+                        )}
                       </Box>
                     </Box>
 
@@ -253,7 +360,8 @@ function ScenarioList({
                 </Stack>
               </CardContent>
             </Card>
-          ))}
+            )
+          })}
           {!error && filteredItems.length === 0 && (
             <Card 
               variant="outlined"

--- a/src/features/roleplay/scenario-list/hooks/useRoleplayFilters.js
+++ b/src/features/roleplay/scenario-list/hooks/useRoleplayFilters.js
@@ -4,6 +4,8 @@ import { useMemo } from 'react'
  * 롤플레이 필터 관리를 위한 커스텀 훅
  * 
  * 탭에 따라 Slack 연동/미연동 시나리오를 구분하여 필터링
+ * Slack 시나리오의 경우 같은 subjectId를 가진 시나리오들을 그룹화하여
+ * Overview 1개와 Detail 1개(드롭다운으로 AI 역할 선택 가능)만 표시
  * 
  * @param {string} tab - 현재 탭 ('linked' | 'created')
  * @param {Array} scenarios - 시나리오 목록
@@ -15,14 +17,75 @@ export default function useRoleplayFilters(tab, scenarios = []) {
   const filteredItems = useMemo(() => {
     if (!Array.isArray(scenarios)) return []
 
+    let filtered = []
+    
     if (tab === 'linked') {
-      // Slack으로 생성된 시나리오만 표시
-      return scenarios.filter((item) => 
+      // Slack으로 생성된 시나리오만 필터링
+      filtered = scenarios.filter((item) => 
         item.creationType === 'SLACK' || item.creationType === 'slack'
       )
+      
+      // 같은 subjectId를 가진 시나리오들을 그룹화
+      const groupedBySubject = {}
+      filtered.forEach((scenario) => {
+        const subjectId = scenario.subjectId
+        if (!subjectId) {
+          // subjectId가 없으면 그대로 추가 (기존 동작 유지)
+          filtered.push(scenario)
+          return
+        }
+        
+        if (!groupedBySubject[subjectId]) {
+          groupedBySubject[subjectId] = {
+            overview: null,
+            details: []
+          }
+        }
+        
+        const topicType = (scenario.topicType || '').toUpperCase()
+        if (topicType === 'OVERVIEW') {
+          groupedBySubject[subjectId].overview = scenario
+        } else if (topicType === 'DETAIL') {
+          groupedBySubject[subjectId].details.push(scenario)
+        }
+      })
+      
+      // 그룹화된 시나리오를 Overview 1개 + Detail 1개로 변환
+      const result = []
+      Object.keys(groupedBySubject).forEach((subjectId) => {
+        const group = groupedBySubject[subjectId]
+        
+        // Overview 시나리오 추가
+        if (group.overview) {
+          result.push({
+            ...group.overview,
+            isGrouped: true,
+            groupType: 'overview'
+          })
+        }
+        
+        // Detail 시나리오 1개 추가 (첫 번째 것을 기본으로, 나머지는 availableAiRoles에 포함)
+        if (group.details.length > 0) {
+          const firstDetail = group.details[0]
+          const availableAiRoles = group.details.map(d => ({
+            aiRole: d.aiRole,
+            scenarioId: d.scenarioId
+          }))
+          
+          result.push({
+            ...firstDetail,
+            isGrouped: true,
+            groupType: 'detail',
+            availableAiRoles, // 드롭다운에서 선택 가능한 AI 역할 목록
+            selectedAiRoleIndex: 0 // 현재 선택된 AI 역할 인덱스
+          })
+        }
+      })
+      
+      return result
     }
 
-    // created 탭은 프롬프트로 생성된 시나리오만 표시
+    // created 탭은 프롬프트로 생성된 시나리오만 표시 (기존 동작 유지)
     return scenarios.filter((item) => 
       item.creationType === 'PROMPT' || item.creationType === 'prompt'
     )

--- a/src/features/roleplay/scenario-list/hooks/useRoleplayFilters.js
+++ b/src/features/roleplay/scenario-list/hooks/useRoleplayFilters.js
@@ -27,11 +27,13 @@ export default function useRoleplayFilters(tab, scenarios = []) {
       
       // 같은 subjectId를 가진 시나리오들을 그룹화
       const groupedBySubject = {}
+      const ungroupedScenarios = [] // subjectId가 없는 시나리오 저장
+      
       filtered.forEach((scenario) => {
         const subjectId = scenario.subjectId
         if (!subjectId) {
-          // subjectId가 없으면 그대로 추가 (기존 동작 유지)
-          filtered.push(scenario)
+          // subjectId가 없으면 별도 배열에 저장
+          ungroupedScenarios.push(scenario)
           return
         }
         
@@ -82,7 +84,8 @@ export default function useRoleplayFilters(tab, scenarios = []) {
         }
       })
       
-      return result
+      // 그룹화된 결과와 subjectId가 없는 시나리오를 병합하여 반환
+      return [...result, ...ungroupedScenarios]
     }
 
     // created 탭은 프롬프트로 생성된 시나리오만 표시 (기존 동작 유지)

--- a/src/features/roleplay/scenario-list/hooks/useScenarioData.js
+++ b/src/features/roleplay/scenario-list/hooks/useScenarioData.js
@@ -19,11 +19,15 @@ export default function useScenarioData() {
     const createdAt = item.createdAt || item.created_at || null
     const createdDate = createdAt ? new Date(createdAt) : null
     const aiRole = item.aiRole || item.ai_role || 'AI 역할 미정'
+    const myRole = item.myRole || item.my_role || null
 
     return {
       scenarioId: item.scenarioId ?? item.id ?? 0,
+      subjectId: item.subjectId ?? item.subject_id ?? null,
       title: item.title || '제목 미정',
       aiRole,
+      myRole,  // 나의 역할 (SLACK=user.jobRole, PROMPT=subject.myRole)
+      topicType: item.topicType || item.topic_type || null,
       status: item.status || 'IN_PROGRESS',
       creationType: item.creationType || item.creation_type || 'UNKNOWN',
       createdAt: createdDate,


### PR DESCRIPTION
## 🧩 개요
Slack 연동 시나리오와 프롬프트 기반 시나리오에서 "나의 역할" 필드가 잘못 표시되던 문제를 수정했습니다. creationType에 따라 올바른 데이터 소스를 사용하도록 변경했습니다.

## 🔗 관련 이슈
Closes #

## 🌿 브랜치 정보
- 브랜치 이름: `feature/<이슈번호>-<작업내용>` 또는 `fix/<이슈번호>-<수정내용>`
- 기준 브랜치: `develop`

> 브랜치 이름 규칙이 맞지 않으면 리뷰 요청 전에 수정해주세요.

## ✅ 변경 사항
- [ ] `useScenarioData`: myRole 정규화 로직 유지 (snake_case/camelCase 대응)

## 🧪 테스트
- Slack 시나리오 조회 시 user.jobRole이 myRole로 표시되는지 확인
- 프롬프트 시나리오 조회 시 subject.myRole이 myRole로 표시되는지 확인
- 시나리오 리스트에서 각 creationType별로 올바른 역할이 표시되는지 확인

## 📸 참고 자료
(선택) 스크린샷, 로그 등

---

> 💡 **PR 생성 시 “Closes #이슈번호”를 포함하면**  
> 병합 시 해당 이슈가 자동으로 닫힙니다.
