### PR TITLE
37 feat roleplaying UI modify

### DIFF
--- a/src/components/Common/ErrorBoundary.jsx
+++ b/src/components/Common/ErrorBoundary.jsx
@@ -117,3 +117,4 @@ export default ErrorBoundary
 
 
 
+

--- a/src/components/Common/LoadingSpinner.jsx
+++ b/src/components/Common/LoadingSpinner.jsx
@@ -45,3 +45,4 @@ export default function LoadingSpinner({ message = '로딩 중...' }) {
 
 
 
+

--- a/src/components/Route/ProtectedRoute.jsx
+++ b/src/components/Route/ProtectedRoute.jsx
@@ -37,3 +37,4 @@ export default function ProtectedRoute({ children }) {
 
 
 
+

--- a/src/features/feedback/pages/FeedbackPage.jsx
+++ b/src/features/feedback/pages/FeedbackPage.jsx
@@ -1,198 +1,246 @@
-import React from 'react'
+import React, { useState, useEffect, lazy, Suspense } from 'react'
 import { 
   Stack, 
   Card, 
   CardContent, 
   Typography, 
-  Box
+  Box,
+  CircularProgress,
+  Alert
 } from '@mui/material'
 import CalendarMonthIcon from '@mui/icons-material/CalendarMonth'
 import SmartToyIcon from '@mui/icons-material/SmartToy'
 import PersonIcon from '@mui/icons-material/Person'
-import useFeedbackPage from '../hooks/useFeedbackPage'
+import { getCompletedSessions, getSessionUtterances } from '../../../services/roleplayService'
+import LoadingSpinner from '../../../components/Common/LoadingSpinner'
 
-// 더미 피드백 데이터 6개
-const MOCK_FEEDBACK_LIST = [
-  {
-    id: 1,
-    scenarioTitle: 'Database Performance Optimization',
-    executedDate: '2024-12-15',
-    aiRole: 'Tech Lead',
-    myRole: 'Backend Developer',
-    sessionId: 'session-1'
-  },
-  {
-    id: 2,
-    scenarioTitle: 'API Endpoint Design Discussion',
-    executedDate: '2024-12-14',
-    aiRole: 'Senior Engineer',
-    myRole: 'Full Stack Developer',
-    sessionId: 'session-2'
-  },
-  {
-    id: 3,
-    scenarioTitle: 'Code Review and Refactoring',
-    executedDate: '2024-12-13',
-    aiRole: 'Engineering Manager',
-    myRole: 'Junior Developer',
-    sessionId: 'session-3'
-  },
-  {
-    id: 4,
-    scenarioTitle: 'System Architecture Planning',
-    executedDate: '2024-12-12',
-    aiRole: 'Architect',
-    myRole: 'Software Engineer',
-    sessionId: 'session-4'
-  },
-  {
-    id: 5,
-    scenarioTitle: 'Bug Fix and Deployment Strategy',
-    executedDate: '2024-12-11',
-    aiRole: 'QA Engineer',
-    myRole: 'DevOps Engineer',
-    sessionId: 'session-5'
-  },
-  {
-    id: 6,
-    scenarioTitle: 'Feature Implementation Discussion',
-    executedDate: '2024-12-10',
-    aiRole: 'Product Manager',
-    myRole: 'Frontend Developer',
-    sessionId: 'session-6'
-  }
-]
+const SummaryView = lazy(() => import('../../roleplay/summary/components/SummaryView'))
 
 export default function FeedbackPage() {
-  const {
-    selectedFeedback,
-    session,
-    handleViewFeedback,
-    handleCloseFeedback
-  } = useFeedbackPage()
-  
-  // 피드백 상세 화면은 기존 로직 유지
-  if (session.view === 'summary') {
+  const [completedSessions, setCompletedSessions] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [selectedSession, setSelectedSession] = useState(null)
+  const [sessionMessages, setSessionMessages] = useState([])
+  const [loadingMessages, setLoadingMessages] = useState(false)
+
+  // 완료된 세션 목록 로드
+  useEffect(() => {
+    const loadCompletedSessions = async () => {
+      setLoading(true)
+      setError(null)
+      try {
+        const sessions = await getCompletedSessions()
+        setCompletedSessions(Array.isArray(sessions) ? sessions : [])
+      } catch (err) {
+        console.error('Failed to load completed sessions:', err)
+        setError('완료된 세션 목록을 불러오는데 실패했습니다.')
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    loadCompletedSessions()
+  }, [])
+
+  // 세션 선택 시 메시지 로드 및 SummaryView 표시
+  const handleSessionClick = async (session) => {
+    setSelectedSession(session)
+    setLoadingMessages(true)
+    try {
+      const utterancesData = await getSessionUtterances(session.sessionId)
+      const utterances = utterancesData?.utterances || []
+      
+      // utterances를 messages 형식으로 변환
+      const messages = utterances.map(utterance => ({
+        who: utterance.speaker === 'user' ? 'You' : 'AI',
+        text: utterance.text || '',
+        translation: utterance.question_ko || null
+      }))
+      
+      setSessionMessages(messages)
+    } catch (err) {
+      console.error('Failed to load session messages:', err)
+      alert('세션 메시지를 불러오는데 실패했습니다.')
+      setSelectedSession(null)
+    } finally {
+      setLoadingMessages(false)
+    }
+  }
+
+  // SummaryView 닫기
+  const handleCloseSummary = () => {
+    setSelectedSession(null)
+    setSessionMessages([])
+  }
+
+  // 피드백 상세 화면 (SummaryView)
+  if (selectedSession) {
+    if (loadingMessages) {
+      return (
+        <Box sx={{ py: { xs: 2, sm: 3 }, px: { xs: 0, sm: 0 }, display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '60vh' }}>
+          <CircularProgress />
+        </Box>
+      )
+    }
+    
     return (
-      <Box sx={{ py: { xs: 2, sm: 3 }, px: { xs: 0, sm: 0 } }}>
-        <Typography variant="h4" sx={{ fontWeight: 700, mb: 2, textAlign: 'center' }}>
-          피드백 상세
-            </Typography>
-        {/* 기존 상세 화면 로직은 유지 */}
-      </Box>
+      <Suspense fallback={<LoadingSpinner message="피드백 로딩 중..." />}>
+        <SummaryView
+          messages={sessionMessages}
+          scenarioTitle={selectedSession.scenarioTitle}
+          sessionId={selectedSession.sessionId}
+          onClose={handleCloseSummary}
+        />
+      </Suspense>
     )
   }
 
   // 피드백 목록 화면
+  if (loading) {
     return (
-        <Stack spacing={3}>
-          {/* 헤더 */}
-          <Stack spacing={0.5} alignItems="center" textAlign="center">
-            <Typography variant="h4" sx={{ fontWeight: 700 }}>
-              피드백
-            </Typography>
-            <Typography variant="body2" color="text.secondary" sx={{ opacity: 0.75 }}>
+      <Box sx={{ py: { xs: 2, sm: 3 }, px: { xs: 0, sm: 0 }, display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '60vh' }}>
+        <CircularProgress />
+      </Box>
+    )
+  }
+
+  if (error) {
+    return (
+      <Box sx={{ py: { xs: 2, sm: 3 }, px: { xs: 0, sm: 0 } }}>
+        <Alert severity="error">{error}</Alert>
+      </Box>
+    )
+  }
+
+  return (
+    <Stack spacing={3}>
+      {/* 헤더 */}
+      <Stack spacing={0.5} alignItems="center" textAlign="center">
+        <Typography variant="h4" sx={{ fontWeight: 700 }}>
+          피드백
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ opacity: 0.75 }}>
           완료된 롤플레잉의 피드백을 확인하세요
-            </Typography>
-          </Stack>
+        </Typography>
+      </Stack>
 
       {/* 피드백 카드 리스트 */}
-      <Stack spacing={2.5}>
-        {MOCK_FEEDBACK_LIST.map((feedback) => (
-              <Card 
-            key={feedback.id}
-            onClick={() => handleViewFeedback(feedback)}
+      {completedSessions.length === 0 ? (
+        <Box sx={{ textAlign: 'center', py: 4 }}>
+          <Typography variant="body2" color="text.secondary">
+            완료된 롤플레잉이 없습니다.
+          </Typography>
+        </Box>
+      ) : (
+        <Stack spacing={2.5}>
+          {completedSessions.map((session) => {
+            // 실행 날짜 포맷팅
+            const executedDate = session.executedDate 
+              ? new Date(session.executedDate).toLocaleDateString('ko-KR', {
+                  year: 'numeric',
+                  month: '2-digit',
+                  day: '2-digit'
+                })
+              : '날짜 정보 없음'
+
+            return (
+              <Card
+                key={session.sessionId}
+                onClick={() => handleSessionClick(session)}
                 sx={{ 
-              borderRadius: 3,
-              border: '1px solid rgba(0,0,0,0.08)',
-              background: 'linear-gradient(135deg, rgba(255,255,255,0.9) 0%, rgba(255,255,255,0.95) 100%)',
-              cursor: 'pointer',
-              transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
-              overflow: 'hidden',
-              position: 'relative',
-              '&::before': {
-                content: '""',
-                position: 'absolute',
-                top: 0,
-                left: 0,
-                width: '4px',
-                height: '100%',
-                background: 'linear-gradient(180deg, #7C6CFF 0%, #4B3CF8 100%)',
-                opacity: 0,
-                transition: 'opacity 0.3s ease'
-              },
+                  borderRadius: 3,
+                  border: '1px solid rgba(0,0,0,0.08)',
+                  background: 'linear-gradient(135deg, rgba(255,255,255,0.9) 0%, rgba(255,255,255,0.95) 100%)',
+                  cursor: 'pointer',
+                  transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+                  overflow: 'hidden',
+                  position: 'relative',
+                  '&::before': {
+                    content: '""',
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    width: '4px',
+                    height: '100%',
+                    background: 'linear-gradient(180deg, #7C6CFF 0%, #4B3CF8 100%)',
+                    opacity: 0,
+                    transition: 'opacity 0.3s ease'
+                  },
                   '&:hover': {
-                boxShadow: '0 8px 24px rgba(124,108,255,0.2)',
-                borderColor: 'rgba(124,108,255,0.3)',
-                transform: 'translateY(-4px)',
-                '&::before': {
-                  opacity: 1
-                }
-              }
-            }}
-          >
-            <CardContent sx={{ p: 3 }}>
-              <Stack spacing={2}>
-                {/* 시나리오 제목 */}
-                  <Typography 
-                  variant="h6" 
-                  fontWeight={700} 
-                    sx={{ 
-                    fontSize: '1.0625rem',
-                    lineHeight: 1.4,
-                    color: '#212121',
-                    flex: 1
-                  }}
-                >
-                  {feedback.scenarioTitle}
-              </Typography>
+                    boxShadow: '0 8px 24px rgba(124,108,255,0.2)',
+                    borderColor: 'rgba(124,108,255,0.3)',
+                    transform: 'translateY(-4px)',
+                    '&::before': {
+                      opacity: 1
+                    }
+                  }
+                }}
+              >
+                <CardContent sx={{ p: 3 }}>
+                  <Stack spacing={2}>
+                    {/* 시나리오 제목 */}
+                    <Typography 
+                      variant="h6" 
+                      fontWeight={700} 
+                      sx={{ 
+                        fontSize: '1.0625rem',
+                        lineHeight: 1.4,
+                        color: '#212121',
+                        flex: 1
+                      }}
+                    >
+                      {session.scenarioTitle}
+                    </Typography>
 
                 {/* 정보 섹션 */}
                 <Stack spacing={1.5}>
                   {/* 나의 역할 */}
                   <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                     <PersonIcon sx={{ fontSize: 18, color: 'primary.main', opacity: 0.8 }} />
-                          <Box>
+                    <Box>
                       <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.25 }}>
                         나의 역할
-                            </Typography>
+                      </Typography>
                       <Typography variant="body2" fontWeight={600} color="text.primary">
-                        {feedback.myRole}
-                              </Typography>
-                      </Box>
-          </Box>
+                        {session.myRole}
+                      </Typography>
+                    </Box>
+                  </Box>
 
                   {/* AI 역할 */}
                   <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                     <SmartToyIcon sx={{ fontSize: 18, color: 'primary.main', opacity: 0.8 }} />
-          <Box>
+                    <Box>
                       <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.25 }}>
                         AI 역할
-            </Typography>
+                      </Typography>
                       <Typography variant="body2" fontWeight={600} color="text.primary">
-                        {feedback.aiRole}
-                    </Typography>
-                  </Box>
+                        {session.aiRole}
+                      </Typography>
+                    </Box>
                   </Box>
 
                   {/* 실행 날짜 */}
                   <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                     <CalendarMonthIcon sx={{ fontSize: 18, color: 'text.secondary', opacity: 0.6 }} />
-                  <Box>
+                    <Box>
                       <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.25 }}>
                         실행 날짜
                       </Typography>
                       <Typography variant="body2" fontWeight={500} color="text.secondary">
-                        {feedback.executedDate}
-                    </Typography>
-                        </Box>
+                        {executedDate}
+                      </Typography>
+                    </Box>
                   </Box>
                 </Stack>
+              </Stack>
+            </CardContent>
+          </Card>
+            )
+          })}
         </Stack>
-              </CardContent>
-            </Card>
-        ))}
-      </Stack>
+      )}
     </Stack>
   )
 }

--- a/src/features/roleplay/pages/RoleplayPage.jsx
+++ b/src/features/roleplay/pages/RoleplayPage.jsx
@@ -126,8 +126,8 @@ export default function RoleplayPage() {
     setOpenEnd,
     currentQuestion,
     session,
-    bookmarked,
-    toggleBookmark,
+    // bookmarked,
+    // toggleBookmark,
     handleEndSession
   } = useSessionControls(scenarios)
 

--- a/src/features/roleplay/pages/RoleplayPage.jsx
+++ b/src/features/roleplay/pages/RoleplayPage.jsx
@@ -112,6 +112,9 @@ export default function RoleplayPage() {
     }
   }, [pendingSlackGeneration, refresh])
 
+  // 롤플레잉 종료 확인 모달 상태
+  const [showSessionEndedModal, setShowSessionEndedModal] = useState(false)
+
   // 롤플레이 세션 관련 (먼저 초기화하여 session을 useCreateScenario에서 사용 가능하도록)
   const {
     tab,
@@ -129,7 +132,12 @@ export default function RoleplayPage() {
     // bookmarked,
     // toggleBookmark,
     handleEndSession
-  } = useSessionControls(scenarios)
+  } = useSessionControls(scenarios, {
+    onSessionEnded: () => {
+      // 세션 종료 시 모달 표시
+      setShowSessionEndedModal(true)
+    }
+  })
 
   // 롤플레이 생성 다이얼로그 관련 (session이 초기화된 후 호출)
   const {
@@ -182,8 +190,8 @@ export default function RoleplayPage() {
     setFeedbackModalOpen(true)
   }
 
-  // 롤플레잉 세션 화면
-  if (session.view === 'session' && session.isSession) {
+  // 롤플레잉 세션 화면 (isSession이 false여도 view가 'session'이면 표시)
+  if (session.view === 'session') {
     return (
       <Suspense fallback={<LoadingSpinner message="세션 로딩 중..." />}>
         <SessionView
@@ -401,6 +409,71 @@ export default function RoleplayPage() {
             </Button>
             <Button 
               onClick={handleConfirmStartRoleplay}
+              variant="contained"
+              sx={{
+                textTransform: 'none',
+                fontWeight: 600,
+                px: 3,
+                background: 'linear-gradient(135deg, #7C6CFF 0%, #4B3CF8 100%)',
+                '&:hover': {
+                  background: 'linear-gradient(135deg, #6B5CE6 0%, #3B2CE8 100%)',
+                }
+              }}
+            >
+              예
+            </Button>
+          </DialogActions>
+        </Dialog>
+
+        {/* 롤플레잉 종료 확인 모달 */}
+        <Dialog
+          open={showSessionEndedModal}
+          onClose={() => setShowSessionEndedModal(false)}
+          aria-labelledby="session-ended-dialog-title"
+          aria-describedby="session-ended-dialog-description"
+          maxWidth="sm"
+          fullWidth
+        >
+          <DialogTitle 
+            id="session-ended-dialog-title"
+            sx={{ 
+              fontWeight: 700,
+              fontSize: '1.25rem',
+              pb: 1
+            }}
+          >
+            롤플레잉이 종료되었습니다
+          </DialogTitle>
+          <DialogContent>
+            <DialogContentText 
+              id="session-ended-dialog-description"
+              sx={{ 
+                fontSize: '0.9375rem',
+                color: 'text.primary',
+                mb: 1
+              }}
+            >
+              피드백을 보시겠습니까?
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions sx={{ px: 3, pb: 2.5 }}>
+            <Button 
+              onClick={() => setShowSessionEndedModal(false)}
+              variant="outlined"
+              sx={{
+                textTransform: 'none',
+                fontWeight: 600,
+                px: 3
+              }}
+            >
+              아니오
+            </Button>
+            <Button 
+              onClick={() => {
+                setShowSessionEndedModal(false)
+                // 피드백 화면으로 이동 (SummaryView가 로딩 처리를 함)
+                session.handleFeedbackView(session.selectedTitle, session.selectedBody)
+              }}
               variant="contained"
               sx={{
                 textTransform: 'none',

--- a/src/features/roleplay/scenario-list/hooks/useScenarioData.js
+++ b/src/features/roleplay/scenario-list/hooks/useScenarioData.js
@@ -58,7 +58,6 @@ export default function useScenarioData() {
         const userInfo = await getCurrentUser()
         setUserJobRole(userInfo.job_role || userInfo.jobRole || null)
       } catch (userError) {
-        console.warn('[useScenarioData] 사용자 정보 조회 실패:', userError)
         setUserJobRole(null)
       }
 
@@ -66,16 +65,9 @@ export default function useScenarioData() {
       let scenariosLoaded = []
       try {
         const result = await fetchUserScenarios()
-        console.log('[DEBUG] API 응답 원본:', result)
-        if (Array.isArray(result) && result.length > 0) {
-          console.log('[DEBUG] 첫 번째 시나리오:', result[0])
-          console.log('[DEBUG] creationType:', result[0].creationType)
-        }
         scenariosLoaded = Array.isArray(result) ? result.map(normalizeScenario) : []
-        console.log('[DEBUG] 정규화된 시나리오:', scenariosLoaded)
         setScenarios(scenariosLoaded)
       } catch (scenarioError) {
-        console.warn('[useScenarioData] 시나리오 로드 실패:', scenarioError)
         setScenarios([])
       }
 
@@ -87,7 +79,6 @@ export default function useScenarioData() {
       try {
         integrated = await checkSlackIntegration()
       } catch (integrationError) {
-        console.warn('[useScenarioData] Slack 연동 상태 확인 중 에러:', integrationError)
         // API 실패 시 SLACK 시나리오 존재 여부로 판단
         integrated = hasSlackScenarios
       }
@@ -97,11 +88,7 @@ export default function useScenarioData() {
     } catch (err) {
       // 로그인 관련 에러만 표시
       if (err.message && err.message.includes('로그인')) {
-        console.error('[useScenarioData] 로그인 필요:', err)
         setError(err.message)
-      } else {
-        // 기타 에러는 조용히 처리 (에러 메시지 표시 안 함)
-        console.warn('[useScenarioData] 시나리오 로드 중 에러 (무시):', err)
       }
       setScenarios([])
       setIsSlackIntegrated(false)

--- a/src/features/roleplay/session/components/MessageBubble.jsx
+++ b/src/features/roleplay/session/components/MessageBubble.jsx
@@ -21,8 +21,15 @@ const TYPING_SPEED = 30
 const STREAMING_TYPING_SPEED = 15 // 스트리밍 중에는 더 빠른 타이핑
 
 function MessageBubble({ message, index, showTranslation, onToggleTranslation, onFetchKeywords }) {
-  const { who, text, isStreaming, translation, recommendedKeywords } = message || {}
+  const { who, text, isStreaming, translation, recommendedKeywords, feedbackSections } = message || {}
   const style = MESSAGE_STYLES[who] || MESSAGE_STYLES.AI
+  
+  // 피드백 타입별 소제목 매핑
+  const feedbackTypeLabels = {
+    pronunciation: '발음',
+    grammar: '문법',
+    relevance: '관련성'
+  }
   const [displayedText, setDisplayedText] = useState('')
   const [isTyping, setIsTyping] = useState(false)
   const [isTranslationVisible, setIsTranslationVisible] = useState(false)
@@ -65,6 +72,11 @@ function MessageBubble({ message, index, showTranslation, onToggleTranslation, o
 
   // AI 메시지 처리 (최적화: 불필요한 업데이트 방지)
   useEffect(() => {
+    // 피드백 섹션이 있으면 타이핑 효과 건너뛰기
+    if (feedbackSections && Array.isArray(feedbackSections) && feedbackSections.length > 0) {
+      return
+    }
+    
     if (who !== 'AI') {
       // 사용자 메시지: STT 중이면 타이핑 효과, 아니면 즉시 표시
       const isSTT = message?.isSTT || false
@@ -300,35 +312,86 @@ function MessageBubble({ message, index, showTranslation, onToggleTranslation, o
               {who}
             </Typography>
           )}
-          {!message.isKeywordsMessage && (
-            <Typography 
-              variant="body2"
-              sx={{
-                lineHeight: 1.6,
-                wordBreak: 'break-word',
-                minHeight: '1em', // 타이핑 중 깜빡임 방지
-                fontSize: '0.75rem'
-              }}
-            >
-              {displayedText || text}
-              {shouldShowCursor && (
-                <Box
-                  component="span"
-                  sx={{
-                    display: 'inline-block',
-                    width: '2px',
-                    height: '1em',
-                    bgcolor: '#212121',
-                    ml: 0.5,
-                    animation: 'blink 1s infinite',
-                    '@keyframes blink': {
-                      '0%, 50%': { opacity: 1 },
-                      '51%, 100%': { opacity: 0 }
-                    }
-                  }}
-                />
-              )}
-            </Typography>
+          {/* 피드백 섹션이 있는 경우 */}
+          {feedbackSections && Array.isArray(feedbackSections) && feedbackSections.length > 0 ? (
+            <Stack spacing={1.5} sx={{ mt: 0.5 }}>
+              {feedbackSections.map((section, idx) => (
+                <Box key={idx}>
+                  <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 0.5 }}>
+                    <Typography
+                      variant="caption"
+                      sx={{
+                        fontSize: '0.7rem',
+                        fontWeight: 600,
+                        color: '#7C6CFF'
+                      }}
+                    >
+                      {feedbackTypeLabels[section.type] || section.type}
+                    </Typography>
+                    {section.score !== undefined && section.score !== null && (
+                      <Chip
+                        label={`${section.score}점`}
+                        size="small"
+                        sx={{
+                          height: 20,
+                          fontSize: '0.65rem',
+                          bgcolor: 'rgba(124,108,255,0.1)',
+                          color: '#7C6CFF',
+                          fontWeight: 600,
+                          border: '1px solid rgba(124,108,255,0.2)',
+                          '& .MuiChip-label': {
+                            px: 0.75,
+                            py: 0
+                          }
+                        }}
+                      />
+                    )}
+                  </Stack>
+                  <Typography
+                    variant="body2"
+                    sx={{
+                      lineHeight: 1.6,
+                      wordBreak: 'break-word',
+                      fontSize: '0.75rem',
+                      color: '#212121'
+                    }}
+                  >
+                    {section.feedback_ko || section.feedback_en}
+                  </Typography>
+                </Box>
+              ))}
+            </Stack>
+          ) : (
+            !message.isKeywordsMessage && (
+              <Typography 
+                variant="body2"
+                sx={{
+                  lineHeight: 1.6,
+                  wordBreak: 'break-word',
+                  minHeight: '1em', // 타이핑 중 깜빡임 방지
+                  fontSize: '0.75rem'
+                }}
+              >
+                {displayedText || text}
+                {shouldShowCursor && (
+                  <Box
+                    component="span"
+                    sx={{
+                      display: 'inline-block',
+                      width: '2px',
+                      height: '1em',
+                      bgcolor: '#212121',
+                      ml: 0.5,
+                      animation: 'blink 1s infinite',
+                      '@keyframes blink': {
+                        '0%, 50%': { opacity: 1 },
+                        '51%, 100%': { opacity: 0 }
+                      }
+                    }}
+                  />
+                )}
+              </Typography>
+            )
           )}
           
           {hasTranslation && isTranslationVisible && (
@@ -453,6 +516,7 @@ export default React.memo(MessageBubble, (prevProps, nextProps) => {
     prevProps.message?.isStreaming === nextProps.message?.isStreaming &&
     prevProps.message?.translation === nextProps.message?.translation &&
     JSON.stringify(prevProps.message?.recommendedKeywords) === JSON.stringify(nextProps.message?.recommendedKeywords) &&
+    JSON.stringify(prevProps.message?.feedbackSections) === JSON.stringify(nextProps.message?.feedbackSections) &&
     prevProps.index === nextProps.index
   )
 })

--- a/src/features/roleplay/session/hooks/useRoleplaySession.js
+++ b/src/features/roleplay/session/hooks/useRoleplaySession.js
@@ -138,15 +138,14 @@ export default function useRoleplaySession() {
 
   /**
    * 피드백 섹션 필터링 및 정렬
-   * grammar와 relevance만 필터링하고 grammar를 먼저 정렬
+   * grammar, pronunciation, relevance를 필터링하고 grammar -> pronunciation -> relevance 순으로 정렬
    */
   const filterAndSortFeedbackSections = (sections) => {
     return sections
-      .filter(section => section.type === 'grammar' || section.type === 'relevance')
+      .filter(section => section.type === 'grammar' || section.type === 'pronunciation' || section.type === 'relevance')
       .sort((a, b) => {
-        if (a.type === 'grammar' && b.type === 'relevance') return -1
-        if (a.type === 'relevance' && b.type === 'grammar') return 1
-        return 0
+        const order = { 'grammar': 0, 'pronunciation': 1, 'relevance': 2 }
+        return (order[a.type] ?? 999) - (order[b.type] ?? 999)
       })
   }
 
@@ -335,12 +334,25 @@ export default function useRoleplaySession() {
   const displayFeedbackMessages = (sections) => {
     const feedbackToShow = filterAndSortFeedbackSections(sections)
     
-    feedbackToShow.forEach((section) => {
-      const translationText = section.feedback_ko
-      const feedbackText = parseFeedbackText(section.feedback_en)
-      
-      addAIMessage(feedbackText, translationText, false, false)
-    })
+    if (feedbackToShow.length === 0) return
+    
+    // 모든 피드백을 하나의 메시지로 합치기
+    const feedbackSections = feedbackToShow.map(section => ({
+      type: section.type,
+      feedback_en: parseFeedbackText(section.feedback_en),
+      feedback_ko: section.feedback_ko,
+      score: section.score
+    }))
+    
+    // 피드백 섹션을 포함한 하나의 메시지 추가 (타이핑 효과 없음)
+    setMessages(prev => [...prev, {
+      who: 'AI',
+      text: '', // 피드백은 feedbackSections로 표시
+      translation: '',
+      isFixedQuestion: false,
+      isStreaming: false,
+      feedbackSections: feedbackSections
+    }])
   }
 
   /**
@@ -628,14 +640,28 @@ export default function useRoleplaySession() {
     if (needsCorrectionRef.current) {
       const feedbackToShow = filterAndSortFeedbackSections(pendingFeedbackSectionsRef.current)
       
-      feedbackToShow.forEach((section) => {
-        const translationText = section.feedback_ko
-        const feedbackText = parseFeedbackText(section.feedback_en)
-        addAIMessage(feedbackText, translationText, false, false)
-      })
+      if (feedbackToShow.length > 0) {
+        // 모든 피드백을 하나의 메시지로 합치기
+        const feedbackSections = feedbackToShow.map(section => ({
+          type: section.type,
+          feedback_en: parseFeedbackText(section.feedback_en),
+          feedback_ko: section.feedback_ko,
+          score: section.score
+        }))
+        
+        // 피드백 섹션을 포함한 하나의 메시지 추가 (타이핑 효과 없음)
+        setMessages(prev => [...prev, {
+          who: 'AI',
+          text: '', // 피드백은 feedbackSections로 표시
+          translation: '',
+          isFixedQuestion: false,
+          isStreaming: false,
+          feedbackSections: feedbackSections
+        }])
+      }
       
       pendingFeedbackSectionsRef.current = pendingFeedbackSectionsRef.current.filter(
-        section => section.type !== 'grammar' && section.type !== 'relevance'
+        section => section.type !== 'grammar' && section.type !== 'pronunciation' && section.type !== 'relevance'
       )
       needsCorrectionRef.current = false
     }

--- a/src/features/roleplay/session/hooks/useRoleplaySession.js
+++ b/src/features/roleplay/session/hooks/useRoleplaySession.js
@@ -46,6 +46,9 @@ const FALLBACK_MESSAGE = "I'm having trouble generating a response. Could you pl
  * - 아바타 애니메이션 제어
  * - 세션 상태 관리 (list, session, summary)
  * 
+ * @param {Object} options - 옵션 객체
+ * @param {Function} options.onSessionEnded - 세션이 자동으로 종료될 때 호출될 콜백 함수
+ * 
  * @returns {Object} 롤플레이 세션 관련 상태 및 핸들러
  *   - isSession: boolean - 세션 활성화 여부
  *   - messages: Array - 대화 메시지 목록
@@ -69,7 +72,8 @@ const FALLBACK_MESSAGE = "I'm having trouble generating a response. Could you pl
  *   - handleFeedbackView: Function - 피드백 뷰로 전환 핸들러
  *   - handleAvatarLoad: Function - 아바타 로드 완료 핸들러
  */
-export default function useRoleplaySession() {
+export default function useRoleplaySession(options = {}) {
+  const { onSessionEnded } = options
   // ========================================
   // State 정의
   // ========================================
@@ -615,7 +619,29 @@ export default function useRoleplaySession() {
       displayFeedbackMessages(pendingFeedbackSectionsRef.current)
       pendingFeedbackSectionsRef.current = []
     }
-    endSession('auto')
+    // 세션 종료만 수행하고, 피드백 화면 자동 이동은 콜백을 통해 처리
+    stopTTS()
+    
+    if (isRecording) {
+      stopRecording()
+    }
+    
+    if (wsConnection && wsConnection.readyState === WebSocket.OPEN) {
+      wsConnection.close()
+    }
+    setWsConnection(null)
+    setIsSession(false)
+    setIsInitialized(false)
+    setIsAvatarLoaded(false)
+    pendingFirstMessageRef.current = null
+    setEvaluating(false)
+    // view를 'session'으로 유지하여 롤플레잉 화면에 머무름 (모달에서 피드백 화면으로 이동하도록)
+    // setView('list') 제거
+    
+    // 콜백이 있으면 호출하여 모달 표시 등의 후처리 수행
+    if (onSessionEnded && typeof onSessionEnded === 'function') {
+      onSessionEnded()
+    }
   }
 
   /**
@@ -637,32 +663,36 @@ export default function useRoleplaySession() {
   const handleFeedbackSections = (message) => {
     storeFeedbackSections(message.sections)
     
-    if (needsCorrectionRef.current) {
-      const feedbackToShow = filterAndSortFeedbackSections(pendingFeedbackSectionsRef.current)
+    // 피드백 섹션이 있으면 항상 표시 (재시도 필요 여부와 관계없이)
+    const feedbackToShow = filterAndSortFeedbackSections(pendingFeedbackSectionsRef.current)
+    
+    if (feedbackToShow.length > 0) {
+      // 모든 피드백을 하나의 메시지로 합치기
+      const feedbackSections = feedbackToShow.map(section => ({
+        type: section.type,
+        feedback_en: parseFeedbackText(section.feedback_en),
+        feedback_ko: section.feedback_ko,
+        score: section.score
+      }))
       
-      if (feedbackToShow.length > 0) {
-        // 모든 피드백을 하나의 메시지로 합치기
-        const feedbackSections = feedbackToShow.map(section => ({
-          type: section.type,
-          feedback_en: parseFeedbackText(section.feedback_en),
-          feedback_ko: section.feedback_ko,
-          score: section.score
-        }))
-        
-        // 피드백 섹션을 포함한 하나의 메시지 추가 (타이핑 효과 없음)
-        setMessages(prev => [...prev, {
-          who: 'AI',
-          text: '', // 피드백은 feedbackSections로 표시
-          translation: '',
-          isFixedQuestion: false,
-          isStreaming: false,
-          feedbackSections: feedbackSections
-        }])
-      }
+      // 피드백 섹션을 포함한 하나의 메시지 추가 (타이핑 효과 없음)
+      setMessages(prev => [...prev, {
+        who: 'AI',
+        text: '', // 피드백은 feedbackSections로 표시
+        translation: '',
+        isFixedQuestion: false,
+        isStreaming: false,
+        feedbackSections: feedbackSections
+      }])
       
+      // 표시한 피드백 섹션은 pending에서 제거
       pendingFeedbackSectionsRef.current = pendingFeedbackSectionsRef.current.filter(
         section => section.type !== 'grammar' && section.type !== 'pronunciation' && section.type !== 'relevance'
       )
+    }
+    
+    // 재시도가 필요한 경우에만 needsCorrectionRef 초기화 (재시도 플로우 유지)
+    if (needsCorrectionRef.current) {
       needsCorrectionRef.current = false
     }
   }

--- a/src/features/roleplay/session/hooks/useSessionControls.js
+++ b/src/features/roleplay/session/hooks/useSessionControls.js
@@ -1,6 +1,6 @@
 import { useState, useMemo } from 'react'
 import useRoleplaySession from './useRoleplaySession'
-import useBookmarks from '../../../../hooks/useBookmarks'
+// import useBookmarks from '../../../../hooks/useBookmarks' // SummaryView에서 사용하지 않으므로 제거
 
 /**
  * 롤플레이 세션 제어를 위한 커스텀 훅
@@ -44,8 +44,8 @@ export default function useSessionControls(scenarios = []) {
   const session = useRoleplaySession()
   
   // 롤플레이 필터 관리 훅 (현재 탭에 따라 필터링)
-  // 북마크 관리 훅
-  const { bookmarked, toggleBookmark } = useBookmarks()
+  // 북마크 관리 훅 (사용하지 않으므로 제거)
+  // const { bookmarked, toggleBookmark } = useBookmarks()
 
   /**
    * 현재 AI 질문 텍스트
@@ -84,8 +84,8 @@ export default function useSessionControls(scenarios = []) {
     
     // Hooks
     session,
-    bookmarked,
-    toggleBookmark,
+    // bookmarked,
+    // toggleBookmark,
     
     // Handlers
     handleEndSession

--- a/src/features/roleplay/session/hooks/useSessionControls.js
+++ b/src/features/roleplay/session/hooks/useSessionControls.js
@@ -1,11 +1,14 @@
 import { useState, useMemo } from 'react'
 import useRoleplaySession from './useRoleplaySession'
-// import useBookmarks from '../../../../hooks/useBookmarks' // SummaryView에서 사용하지 않으므로 제거
 
 /**
  * 롤플레이 세션 제어를 위한 커스텀 훅
  * 
- * 롤플레이 세션, 탭, 캘린더, 북마크 등을 통합 관리
+ * 롤플레이 세션, 탭, 캘린더 등을 통합 관리
+ * 
+ * @param {Array} scenarios - 시나리오 목록
+ * @param {Object} options - 옵션 객체
+ * @param {Function} options.onSessionEnded - 세션이 자동으로 종료될 때 호출될 콜백 함수
  * 
  * @returns {Object} 롤플레이 세션 제어 관련 상태 및 핸들러
  *   - tab: string - 현재 탭 ('linked' | 'created')
@@ -20,11 +23,10 @@ import useRoleplaySession from './useRoleplaySession'
  *   - setOpenEnd: Function - 세션 종료 다이얼로그 열림 상태 변경 핸들러
  *   - currentQuestion: string - 현재 AI 질문 텍스트
  *   - session: Object - 롤플레이 세션 훅 반환값
- *   - bookmarked: Set - 북마크된 항목 ID Set
- *   - toggleBookmark: Function - 북마크 토글 핸들러
  *   - handleEndSession: Function - 세션 종료 핸들러
  */
-export default function useSessionControls(scenarios = []) {
+export default function useSessionControls(scenarios = [], options = {}) {
+  const { onSessionEnded } = options
   // 현재 탭 상태 ('linked': 연결된 시나리오, 'created': 생성한 시나리오)
   const [tab, setTab] = useState('linked')
   
@@ -41,11 +43,9 @@ export default function useSessionControls(scenarios = []) {
   const [openEnd, setOpenEnd] = useState(false)
 
   // 롤플레이 세션 관리 훅
-  const session = useRoleplaySession()
-  
-  // 롤플레이 필터 관리 훅 (현재 탭에 따라 필터링)
-  // 북마크 관리 훅 (사용하지 않으므로 제거)
-  // const { bookmarked, toggleBookmark } = useBookmarks()
+  const session = useRoleplaySession({
+    onSessionEnded
+  })
 
   /**
    * 현재 AI 질문 텍스트
@@ -84,8 +84,6 @@ export default function useSessionControls(scenarios = []) {
     
     // Hooks
     session,
-    // bookmarked,
-    // toggleBookmark,
     
     // Handlers
     handleEndSession

--- a/src/features/roleplay/summary/components/SummaryView.jsx
+++ b/src/features/roleplay/summary/components/SummaryView.jsx
@@ -50,6 +50,8 @@ export default function SummaryView({
   const [messageIdMap, setMessageIdMap] = useState({}) // utterance_index -> messageId 매핑
   const [pendingBookmarks, setPendingBookmarks] = useState(new Set()) // 선택된 북마크 messageId들 (닫기 버튼에서 저장)
   const [savingBookmarks, setSavingBookmarks] = useState(false) // 북마크 저장 중 상태
+  const [utterances, setUtterances] = useState([]) // utterances 데이터 (피드백 포함)
+  const [expandedFeedback, setExpandedFeedback] = useState({}) // 피드백 토글 상태 (messageId -> boolean)
 
   const normalizedMessages = normalizeConversationMessages(messages)
   const displayMessages = normalizedMessages.length > 0 ? normalizedMessages : MOCK_CONVERSATION
@@ -90,6 +92,7 @@ export default function SummaryView({
         })
         
         setMessageIdMap(idMap)
+        setUtterances(sortedUtterances) // utterances 데이터 저장
       } catch (err) {
         console.error('[SummaryView] Failed to load utterances:', err)
       }
@@ -366,6 +369,19 @@ export default function SummaryView({
                 const messageId = messageIdMap[idx]
                 const isBookmarked = bookmarkedMessages[messageKey] || (messageId && pendingBookmarks.has(messageId))
                 
+                // 사용자 발화인 경우 utterances에서 피드백 데이터 찾기
+                const userUtterance = isUser && messageId 
+                  ? utterances.find(u => u.id === messageId && (u.speaker === 'user' || u.speaker === 'USER'))
+                  : null
+                
+                const hasFeedback = userUtterance && (
+                  userUtterance.pronunciation_score !== null || 
+                  userUtterance.grammar_score !== null || 
+                  userUtterance.relevance_score !== null ||
+                  (userUtterance.feedback_sections && userUtterance.feedback_sections.length > 0)
+                )
+                const isFeedbackExpanded = expandedFeedback[messageId] || false
+                
                 return (
                   <Box key={messageKey} sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
                     <Stack direction="row" spacing={1} alignItems="center" justifyContent={isUser ? 'flex-end' : 'flex-start'}>
@@ -455,6 +471,187 @@ export default function SummaryView({
                         )}
                       </CardContent>
                     </Card>
+                    
+                    {/* 사용자 발화 밑에 피드백 점수 및 내용 */}
+                    {isUser && hasFeedback && (
+                      <Box sx={{ alignSelf: 'flex-end', maxWidth: '88%', mt: 0.5 }}>
+                        {/* 점수는 기본으로 항상 표시 */}
+                        {(userUtterance.pronunciation_score !== null || 
+                          userUtterance.grammar_score !== null || 
+                          userUtterance.relevance_score !== null) && (
+                          <Stack direction="row" spacing={1} flexWrap="wrap" gap={1} sx={{ mb: 1 }}>
+                            {userUtterance.pronunciation_score !== null && (
+                              <Chip
+                                label={`발음: ${userUtterance.pronunciation_score}점`}
+                                size="small"
+                                sx={{
+                                  bgcolor: 'rgba(124,108,255,0.1)',
+                                  color: 'primary.main',
+                                  fontWeight: 600
+                                }}
+                              />
+                            )}
+                            {userUtterance.grammar_score !== null && (
+                              <Chip
+                                label={`문법: ${userUtterance.grammar_score}점`}
+                                size="small"
+                                sx={{
+                                  bgcolor: 'rgba(124,108,255,0.1)',
+                                  color: 'primary.main',
+                                  fontWeight: 600
+                                }}
+                              />
+                            )}
+                            {userUtterance.relevance_score !== null && (
+                              <Chip
+                                label={`관련성: ${userUtterance.relevance_score}점`}
+                                size="small"
+                                sx={{
+                                  bgcolor: 'rgba(124,108,255,0.1)',
+                                  color: 'primary.main',
+                                  fontWeight: 600
+                                }}
+                              />
+                            )}
+                          </Stack>
+                        )}
+                        
+                        {/* 피드백 내용이 있는 경우에만 토글 버튼 표시 */}
+                        {(() => {
+                          const feedbackSections = userUtterance?.feedback_sections || userUtterance?.feedbackSections
+                          const hasFeedbackContent = feedbackSections && Array.isArray(feedbackSections) && feedbackSections.length > 0 && 
+                            feedbackSections.some(section => {
+                              const feedbackKo = section.feedback_ko || section.feedbackKo
+                              const feedbackEn = section.feedback_en || section.feedbackEn
+                              return feedbackKo || feedbackEn
+                            })
+                          
+                          if (!hasFeedbackContent) {
+                            return null
+                          }
+                          
+                          return (
+                            <>
+                              <Button
+                                variant="text"
+                                size="small"
+                                onClick={() => {
+                                  setExpandedFeedback(prev => ({
+                                    ...prev,
+                                    [messageId]: !prev[messageId]
+                                  }))
+                                }}
+                                endIcon={
+                                  <ExpandMoreIcon 
+                                    sx={{ 
+                                      transform: isFeedbackExpanded ? 'rotate(180deg)' : 'rotate(0deg)',
+                                      transition: 'transform 0.2s ease'
+                                    }} 
+                                  />
+                                }
+                                sx={{
+                                  textTransform: 'none',
+                                  color: 'primary.main',
+                                  fontWeight: 600,
+                                  fontSize: '0.75rem',
+                                  py: 0.5,
+                                  px: 1
+                                }}
+                              >
+                                피드백 보기
+                              </Button>
+                              <Collapse in={isFeedbackExpanded} timeout="auto" unmountOnExit>
+                                <Card
+                                  variant="outlined"
+                                  sx={{
+                                    mt: 1,
+                                    bgcolor: 'rgba(124,108,255,0.04)',
+                                    border: '1px solid rgba(124,108,255,0.15)',
+                                    borderRadius: 2
+                                  }}
+                                >
+                                  <CardContent sx={{ py: 1.5, px: 2 }}>
+                                    {/* 피드백 섹션 표시 (롤플레잉 도중 채팅과 동일한 형식) */}
+                                    {(() => {
+                                      const feedbackTypeLabels = {
+                                        pronunciation: '발음',
+                                        grammar: '문법',
+                                        relevance: '관련성'
+                                      }
+                                      
+                                      return (
+                                        <Stack spacing={1.5}>
+                                          {feedbackSections.map((section, sectionIdx) => {
+                                            // 필드명 변형 지원 (snake_case, camelCase)
+                                            const feedbackKo = section.feedback_ko || section.feedbackKo
+                                            const feedbackEn = section.feedback_en || section.feedbackEn
+                                            // 롤플레잉 도중과 동일하게 한글 우선, 없으면 영문
+                                            const feedbackText = feedbackKo || feedbackEn
+                                            const score = section.score !== null && section.score !== undefined ? section.score : null
+                                            
+                                            // 피드백 텍스트가 없는 섹션은 표시하지 않음
+                                            if (!feedbackText) {
+                                              return null
+                                            }
+                                            
+                                            return (
+                                              <Box key={sectionIdx}>
+                                                <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 0.5 }}>
+                                                  <Typography
+                                                    variant="caption"
+                                                    sx={{
+                                                      fontSize: '0.7rem',
+                                                      fontWeight: 600,
+                                                      color: '#7C6CFF'
+                                                    }}
+                                                  >
+                                                    {feedbackTypeLabels[section.type] || section.type}
+                                                  </Typography>
+                                                  {score !== null && score !== undefined && (
+                                                    <Chip
+                                                      label={`${score}점`}
+                                                      size="small"
+                                                      sx={{
+                                                        height: 20,
+                                                        fontSize: '0.65rem',
+                                                        bgcolor: 'rgba(124,108,255,0.1)',
+                                                        color: '#7C6CFF',
+                                                        fontWeight: 600,
+                                                        border: '1px solid rgba(124,108,255,0.2)',
+                                                        '& .MuiChip-label': {
+                                                          px: 0.75,
+                                                          py: 0
+                                                        }
+                                                      }}
+                                                    />
+                                                  )}
+                                                </Stack>
+                                                <Typography
+                                                  variant="body2"
+                                                  sx={{
+                                                    lineHeight: 1.6,
+                                                    wordBreak: 'break-word',
+                                                    fontSize: '0.75rem',
+                                                    color: '#212121'
+                                                  }}
+                                                >
+                                                  {feedbackText}
+                                                </Typography>
+                                                {sectionIdx < feedbackSections.length - 1 && <Divider sx={{ mt: 1.5 }} />}
+                                              </Box>
+                                            )
+                                          })}
+                                        </Stack>
+                                      )
+                                    })()}
+                                  </CardContent>
+                                </Card>
+                              </Collapse>
+                            </>
+                          )
+                        })()}
+                      </Box>
+                    )}
                   </Box>
                 )
               })}

--- a/src/features/roleplay/summary/components/SummaryView.jsx
+++ b/src/features/roleplay/summary/components/SummaryView.jsx
@@ -16,7 +16,8 @@ import {
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import TranslateIcon from '@mui/icons-material/Translate'
 import BookmarkIcon from '@mui/icons-material/Bookmark'
-import { getComprehensiveFeedback } from '../../../../services/roleplayService'
+import { getComprehensiveFeedback, getSessionUtterances } from '../../../../services/roleplayService'
+import { createBookmark } from '../../../../services/bookmarkService'
 import LoadingSpinner from '../../../../components/Common/LoadingSpinner'
 
 const normalizeConversationMessages = (rawMessages = []) => {
@@ -46,9 +47,57 @@ export default function SummaryView({
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
   const [bookmarkedMessages, setBookmarkedMessages] = useState({})
+  const [messageIdMap, setMessageIdMap] = useState({}) // utterance_index -> messageId 매핑
+  const [pendingBookmarks, setPendingBookmarks] = useState(new Set()) // 선택된 북마크 messageId들 (닫기 버튼에서 저장)
+  const [savingBookmarks, setSavingBookmarks] = useState(false) // 북마크 저장 중 상태
 
   const normalizedMessages = normalizeConversationMessages(messages)
   const displayMessages = normalizedMessages.length > 0 ? normalizedMessages : MOCK_CONVERSATION
+
+  // utterances 가져와서 messageId 매핑 (한 번만 실행)
+  useEffect(() => {
+    if (!sessionId) return
+
+    const loadUtterances = async () => {
+      try {
+        const utterancesData = await getSessionUtterances(sessionId)
+        const utterances = utterancesData?.utterances || []
+        
+        // utterances를 turn_index 순서로 정렬
+        const sortedUtterances = [...utterances].sort((a, b) => 
+          (a.utterance_index || 0) - (b.utterance_index || 0)
+        )
+        
+        // displayMessages의 인덱스와 utterances의 turn_index를 매칭
+        // displayMessages는 AI와 User가 번갈아 나오므로, turn_index로 직접 매칭 불가
+        // 대신 텍스트 매칭으로 user 메시지의 messageId 찾기
+        const idMap = {}
+        const currentDisplayMessages = normalizedMessages.length > 0 ? normalizedMessages : MOCK_CONVERSATION
+        
+        sortedUtterances.forEach(utterance => {
+          if ((utterance.speaker === 'user' || utterance.speaker === 'USER') && utterance.id) {
+            // currentDisplayMessages에서 같은 텍스트를 가진 사용자 메시지 찾기
+            currentDisplayMessages.forEach((msg, idx) => {
+              if (msg.who === 'You' && msg.text && utterance.text) {
+                const msgText = msg.text.trim()
+                const utteranceText = utterance.text.trim()
+                if (msgText === utteranceText) {
+                  idMap[idx] = utterance.id
+                }
+              }
+            })
+          }
+        })
+        
+        setMessageIdMap(idMap)
+      } catch (err) {
+        console.error('[SummaryView] Failed to load utterances:', err)
+      }
+    }
+
+    loadUtterances()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionId]) // displayMessages 제거 - messages prop이 변경될 때만 재실행되도록
 
   // 종합 피드백 조회 (피드백 생성 완료까지 대기)
   useEffect(() => {
@@ -123,8 +172,45 @@ export default function SummaryView({
         <Alert severity="warning" sx={{ mb: 1 }}>
           {error}
         </Alert>
-        <Button variant="outlined" onClick={onClose} sx={{ mt: 2 }}>
-          닫기
+        <Button 
+          variant="outlined" 
+          onClick={async () => {
+            // 선택된 북마크들을 일괄 저장
+            if (pendingBookmarks.size > 0) {
+              setSavingBookmarks(true)
+              try {
+                const messageIds = Array.from(pendingBookmarks)
+                
+                const bookmarkPromises = messageIds.map(messageId => 
+                  createBookmark(messageId).catch(err => {
+                    return { error: true, messageId, errorMessage: err?.message || 'Unknown error' }
+                  })
+                )
+                
+                const results = await Promise.all(bookmarkPromises)
+                const successCount = results.filter(r => r === undefined || (r && !r.error)).length
+                const failedResults = results.filter(r => r && r.error)
+                
+                if (failedResults.length > 0) {
+                  alert(`북마크 저장 실패: ${failedResults.length}개 실패\n\n실패한 메시지 ID: ${failedResults.map(f => f.messageId).join(', ')}\n\n에러: ${failedResults[0]?.errorMessage || '알 수 없는 오류'}`)
+                }
+                
+                // 저장 완료 후 상태 초기화
+                setPendingBookmarks(new Set())
+              } catch (err) {
+                alert('북마크 저장 중 오류가 발생했습니다: ' + (err?.message || '알 수 없는 오류'))
+              } finally {
+                setSavingBookmarks(false)
+              }
+            }
+            
+            // 닫기 콜백 실행
+            onClose()
+          }}
+          disabled={savingBookmarks}
+          sx={{ mt: 2 }}
+        >
+          {savingBookmarks ? '저장 중...' : pendingBookmarks.size > 0 ? `닫기 (${pendingBookmarks.size}개 저장)` : '닫기'}
         </Button>
       </Box>
     )
@@ -277,7 +363,8 @@ export default function SummaryView({
               {displayMessages.map((msg, idx) => {
                 const isUser = msg.who === 'You'
                 const messageKey = `${msg.who}-${idx}`
-                const isBookmarked = bookmarkedMessages[messageKey] || false
+                const messageId = messageIdMap[idx]
+                const isBookmarked = bookmarkedMessages[messageKey] || (messageId && pendingBookmarks.has(messageId))
                 
                 return (
                   <Box key={messageKey} sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
@@ -299,11 +386,33 @@ export default function SummaryView({
                         <IconButton
                           size="small"
                           onClick={() => {
-                            setBookmarkedMessages(prev => ({
-                              ...prev,
-                              [messageKey]: !prev[messageKey]
-                            }))
+                            const utteranceIndex = idx
+                            const messageId = messageIdMap[utteranceIndex]
+                            
+                            if (!messageId) {
+                              return
+                            }
+
+                            // 로컬 상태만 변경 (즉시 DB 저장하지 않음)
+                            setPendingBookmarks(prev => {
+                              const newSet = new Set(prev)
+                              if (newSet.has(messageId)) {
+                                newSet.delete(messageId)
+                                setBookmarkedMessages(prevMsgs => ({
+                                  ...prevMsgs,
+                                  [messageKey]: false
+                                }))
+                              } else {
+                                newSet.add(messageId)
+                                setBookmarkedMessages(prevMsgs => ({
+                                  ...prevMsgs,
+                                  [messageKey]: true
+                                }))
+                              }
+                              return newSet
+                            })
                           }}
+                          disabled={!messageIdMap[idx] || savingBookmarks}
                           sx={{
                             padding: 0.25,
                             minWidth: 'auto',
@@ -353,8 +462,45 @@ export default function SummaryView({
           </Collapse>
         </Box>
 
-        <Button variant="outlined" onClick={onClose} sx={{ mt: 2 }}>
-          닫기
+        <Button 
+          variant="outlined" 
+          onClick={async () => {
+            // 선택된 북마크들을 일괄 저장
+            if (pendingBookmarks.size > 0) {
+              setSavingBookmarks(true)
+              try {
+                const messageIds = Array.from(pendingBookmarks)
+                
+                const bookmarkPromises = messageIds.map(messageId => 
+                  createBookmark(messageId).catch(err => {
+                    return { error: true, messageId, errorMessage: err?.message || 'Unknown error' }
+                  })
+                )
+                
+                const results = await Promise.all(bookmarkPromises)
+                const successCount = results.filter(r => r === undefined || (r && !r.error)).length
+                const failedResults = results.filter(r => r && r.error)
+                
+                if (failedResults.length > 0) {
+                  alert(`북마크 저장 실패: ${failedResults.length}개 실패\n\n실패한 메시지 ID: ${failedResults.map(f => f.messageId).join(', ')}\n\n에러: ${failedResults[0]?.errorMessage || '알 수 없는 오류'}`)
+                }
+                
+                // 저장 완료 후 상태 초기화
+                setPendingBookmarks(new Set())
+              } catch (err) {
+                alert('북마크 저장 중 오류가 발생했습니다: ' + (err?.message || '알 수 없는 오류'))
+              } finally {
+                setSavingBookmarks(false)
+              }
+            }
+            
+            // 닫기 콜백 실행
+            onClose()
+          }}
+          disabled={savingBookmarks}
+          sx={{ mt: 2 }}
+        >
+          {savingBookmarks ? '저장 중...' : pendingBookmarks.size > 0 ? `닫기 (${pendingBookmarks.size}개 저장)` : '닫기'}
         </Button>
       </Stack>
     </Box>

--- a/src/features/user/components/BookmarkList.jsx
+++ b/src/features/user/components/BookmarkList.jsx
@@ -1,23 +1,8 @@
-import { useState } from 'react'
-import { Typography, Stack, Box, Chip, CircularProgress, Alert, IconButton, Collapse } from '@mui/material'
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import { Typography, Stack, Box, Chip, CircularProgress, Alert } from '@mui/material'
 import useBookmarks from '../../../hooks/useBookmarks'
 
 export default function BookmarkList() {
   const { bookmarks, loading, error } = useBookmarks()
-  const [expandedIds, setExpandedIds] = useState(new Set())
-
-  const toggleExpand = (bookmarkId) => {
-    setExpandedIds(prev => {
-      const newSet = new Set(prev)
-      if (newSet.has(bookmarkId)) {
-        newSet.delete(bookmarkId)
-      } else {
-        newSet.add(bookmarkId)
-      }
-      return newSet
-    })
-  }
 
   if (loading) {
     return (
@@ -48,8 +33,6 @@ export default function BookmarkList() {
   return (
     <Stack spacing={2}>
       {bookmarks.map((bookmark, idx) => {
-        const isExpanded = expandedIds.has(bookmark.bookmarkId)
-
         return (
           <Box
             key={bookmark.bookmarkId}
@@ -133,26 +116,10 @@ export default function BookmarkList() {
                 </Stack>
               )}
 
-              {/* 상세보기 버튼 */}
+              {/* 피드백 상세 내용 (항상 표시) */}
               {bookmark.feedbackSections && bookmark.feedbackSections.length > 0 && (
-                <Box sx={{ display: 'flex', justifyContent: 'center', mt: 1 }}>
-                  <IconButton
-                    onClick={() => toggleExpand(bookmark.bookmarkId)}
-                    size="small"
-                    sx={{
-                      transform: isExpanded ? 'rotate(180deg)' : 'rotate(0deg)',
-                      transition: 'transform 0.3s'
-                    }}
-                  >
-                    <ExpandMoreIcon />
-                  </IconButton>
-                </Box>
-              )}
-
-              {/* 피드백 상세 내용 (접기/펼치기) */}
-              <Collapse in={isExpanded} timeout="auto" unmountOnExit>
                 <Stack spacing={1.5} sx={{ mt: 1 }}>
-                  {bookmark.feedbackSections?.map((section) => {
+                  {bookmark.feedbackSections.map((section) => {
                     const typeLabel = section.type === 'pronunciation' ? '발음 피드백' :
                                      section.type === 'grammar' ? '문법 피드백' : '문맥 피드백'
 
@@ -183,7 +150,7 @@ export default function BookmarkList() {
                     )
                   })}
                 </Stack>
-              </Collapse>
+              )}
             </Stack>
           </Box>
         )

--- a/src/features/user/pages/UserPage.jsx
+++ b/src/features/user/pages/UserPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useEffect } from 'react'
 import { 
   Typography, 
   Stack, 
@@ -7,201 +7,21 @@ import {
   Box,
   Chip,
   IconButton,
-  Collapse,
   Divider,
   CircularProgress,
   Alert
 } from '@mui/material'
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
-import ExpandLessIcon from '@mui/icons-material/ExpandLess'
 import BookmarkIcon from '@mui/icons-material/Bookmark'
 import useBookmarks from '../../../hooks/useBookmarks'
 
-// 더미 북마크 채팅 데이터 5개
-const MOCK_BOOKMARKED_CHATS = [
-  {
-    id: 1,
-    scenarioTitle: 'Database Performance Optimization',
-    executedDate: '2024-12-15',
-    aiRole: 'Tech Lead',
-    myRole: 'Backend Developer',
-    aiQuestion: 'Can you walk me through the reasoning behind adding these specific evaluation-related columns and indexes to the scenario_message and scenario_session tables?',
-    myAnswer: 'We\'ve identified the root cause. The issue is in the report generation module where we\'re not properly handling the new finance filters. We\'re implementing a temporary workaround by caching the filter results, and this expect to have a permanent fix by next week.',
-    bookmarkDate: '2024-12-15 14:30',
-    sessionId: 'session-1',
-    scores: {
-      pronunciation: 85,
-      grammar: 92,
-      relevance: 88
-    },
-    feedbacks: {
-      pronunciation: {
-        feedback_en: 'Your pronunciation is generally clear, but pay attention to the stress on "evaluation" and "indexes". The word "scenario" could be pronounced with more emphasis on the second syllable.',
-        feedback_ko: '발음이 전반적으로 명확하지만, "evaluation"과 "indexes"의 강세에 주의하세요. "scenario"는 두 번째 음절에 더 강세를 주어 발음하면 좋습니다.',
-        score: 85
-      },
-      grammar: {
-        feedback_en: 'Minor grammatical issue: "this expect" should be "we expect". Otherwise, the sentence structure is well-formed.',
-        feedback_ko: '작은 문법 오류: "this expect"는 "we expect"로 수정해야 합니다. 그 외에는 문장 구조가 잘 형성되어 있습니다.',
-        score: 92
-      },
-      relevance: {
-        feedback_en: 'Your response directly addresses the question about reasoning and implementation details. Good connection to the technical context.',
-        feedback_ko: '답변이 추론과 구현 세부사항에 대한 질문을 직접적으로 다루고 있습니다. 기술적 맥락과의 연결이 좋습니다.',
-        score: 88
-      }
-    }
-  },
-  {
-    id: 2,
-    scenarioTitle: 'API Endpoint Design Discussion',
-    executedDate: '2024-12-14',
-    aiRole: 'Senior Engineer',
-    myRole: 'Full Stack Developer',
-    aiQuestion: 'How do you plan to validate and test the effectiveness of the proposed indexing/query tuning for complex finance filters?',
-    myAnswer: 'We\'ll test it first on staging with real-like finance filter cases and compare latency/DB load before vs after. If the results look stable, we\'ll roll it out gradually to production.',
-    bookmarkDate: '2024-12-14 16:20',
-    sessionId: 'session-2',
-    scores: {
-      pronunciation: 78,
-      grammar: 95,
-      relevance: 90
-    },
-    feedbacks: {
-      pronunciation: {
-        feedback_en: 'The pronunciation of "validate" and "effectiveness" needs improvement. Try to enunciate each syllable more clearly.',
-        feedback_ko: '"validate"와 "effectiveness"의 발음이 개선이 필요합니다. 각 음절을 더 명확하게 발음해보세요.',
-        score: 78
-      },
-      grammar: {
-        feedback_en: 'Excellent grammar throughout. The sentence structure is professional and clear.',
-        feedback_ko: '전반적으로 문법이 우수합니다. 문장 구조가 전문적이고 명확합니다.',
-        score: 95
-      },
-      relevance: {
-        feedback_en: 'Your answer provides a clear testing strategy that directly relates to the question about validation methods.',
-        feedback_ko: '답변이 검증 방법에 대한 질문과 직접적으로 관련된 명확한 테스트 전략을 제공합니다.',
-        score: 90
-      }
-    }
-  },
-  {
-    id: 3,
-    scenarioTitle: 'Code Review and Refactoring',
-    executedDate: '2024-12-13',
-    aiRole: 'Engineering Manager',
-    myRole: 'Junior Developer',
-    aiQuestion: 'Can you elaborate on how you plan to handle any potential performance regressions during the gradual roll-out?',
-    myAnswer: 'If we see regressions, we\'ll pause or roll back the canary and check logs/metrics to find the cause. We\'ll add extra monitoring for Redis timeouts, pool usage, and endpoint latency.',
-    bookmarkDate: '2024-12-13 11:15',
-    sessionId: 'session-3',
-    scores: {
-      pronunciation: 82,
-      grammar: 88,
-      relevance: 85
-    },
-    feedbacks: {
-      pronunciation: {
-        feedback_en: 'Good overall pronunciation. Work on the clarity of "regressions" and "canary" for better communication.',
-        feedback_ko: '전반적으로 발음이 좋습니다. "regressions"와 "canary"의 명확성을 개선하면 더 좋습니다.',
-        score: 82
-      },
-      grammar: {
-        feedback_en: 'Mostly correct grammar. Consider using "we will" instead of "we\'ll" in formal contexts for better clarity.',
-        feedback_ko: '대부분 문법이 정확합니다. 공식적인 맥락에서는 "we\'ll" 대신 "we will"을 사용하는 것이 더 명확합니다.',
-        score: 88
-      },
-      relevance: {
-        feedback_en: 'Your response addresses the question about handling regressions, though it could be more specific about the monitoring approach.',
-        feedback_ko: '답변이 회귀 문제 처리에 대한 질문을 다루고 있지만, 모니터링 접근 방식에 대해 더 구체적일 수 있습니다.',
-        score: 85
-      }
-    }
-  },
-  {
-    id: 4,
-    scenarioTitle: 'System Architecture Planning',
-    executedDate: '2024-12-12',
-    aiRole: 'Architect',
-    myRole: 'Software Engineer',
-    aiQuestion: 'What are the next steps to resolve the issue, and when can we expect a fix or further updates from your team?',
-    myAnswer: 'We\'re wrapping up the fix now and will run final tests soon. You can expect an update shortly, and we plan to deliver the final patch within the next few days.',
-    bookmarkDate: '2024-12-12 09:45',
-    sessionId: 'session-4',
-    scores: {
-      pronunciation: 90,
-      grammar: 93,
-      relevance: 87
-    },
-    feedbacks: {
-      pronunciation: {
-        feedback_en: 'Excellent pronunciation. All technical terms are clearly articulated and easy to understand.',
-        feedback_ko: '발음이 우수합니다. 모든 기술 용어가 명확하게 발음되어 이해하기 쉽습니다.',
-        score: 90
-      },
-      grammar: {
-        feedback_en: 'Very good grammar with only minor improvements possible. The use of "we\'re" and "we plan" is appropriate.',
-        feedback_ko: '문법이 매우 좋으며, 작은 개선만 가능합니다. "we\'re"와 "we plan"의 사용이 적절합니다.',
-        score: 93
-      },
-      relevance: {
-        feedback_en: 'Your response provides a timeline and next steps, which addresses the question, though more detail on the specific steps would strengthen it.',
-        feedback_ko: '답변이 타임라인과 다음 단계를 제공하여 질문에 답하고 있지만, 구체적인 단계에 대한 더 자세한 설명이 있으면 더 좋습니다.',
-        score: 87
-      }
-    }
-  },
-  {
-    id: 5,
-    scenarioTitle: 'Bug Fix and Deployment Strategy',
-    executedDate: '2024-12-11',
-    aiRole: 'QA Engineer',
-    myRole: 'DevOps Engineer',
-    aiQuestion: 'Can you explain how you envision the process of analyzing and addressing potential root causes for performance regressions?',
-    myAnswer: 'We\'ll check alerts first, then compare metrics before/after the rollout to spot what changed. If needed, we\'ll reproduce it on staging, fix the specific part, and redeploy quickly.',
-    bookmarkDate: '2024-12-11 15:30',
-    sessionId: 'session-5',
-    scores: {
-      pronunciation: 88,
-      grammar: 90,
-      relevance: 92
-    },
-    feedbacks: {
-      pronunciation: {
-        feedback_en: 'Clear pronunciation overall. Pay attention to the stress pattern in "analyzing" and "addressing" for more natural flow.',
-        feedback_ko: '전반적으로 발음이 명확합니다. 더 자연스러운 흐름을 위해 "analyzing"과 "addressing"의 강세 패턴에 주의하세요.',
-        score: 88
-      },
-      grammar: {
-        feedback_en: 'Good grammatical structure. The sentence flow is clear and professional.',
-        feedback_ko: '문법 구조가 좋습니다. 문장 흐름이 명확하고 전문적입니다.',
-        score: 90
-      },
-      relevance: {
-        feedback_en: 'Excellent response that directly explains the process of analyzing and addressing root causes, with clear steps outlined.',
-        feedback_ko: '근본 원인 분석 및 해결 과정을 직접적으로 설명하고 명확한 단계를 제시하는 우수한 답변입니다.',
-        score: 92
-      }
-    }
-  }
-]
-
 export default function UserPage() {
   const { bookmarks, loading, error, removeBookmark, refreshBookmarks } = useBookmarks()
-  const [expandedCards, setExpandedCards] = useState({})
 
   // UserPage 마운트 시 북마크 목록 로드 (한 번만 실행)
   useEffect(() => {
     refreshBookmarks()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
-
-  const handleToggleExpand = (bookmarkId) => {
-    setExpandedCards(prev => ({
-      ...prev,
-      [bookmarkId]: !prev[bookmarkId]
-    }))
-  }
 
   const handleDeleteBookmark = async (bookmarkId) => {
     if (window.confirm('북마크를 삭제하시겠습니까?')) {
@@ -248,14 +68,6 @@ export default function UserPage() {
       )}
       <Stack spacing={2.5}>
         {Array.isArray(bookmarks) && bookmarks.map((bookmark) => {
-          // feedbackSections를 맵으로 변환 (type을 키로)
-          const feedbacksMap = {}
-          if (bookmark.feedbackSections && Array.isArray(bookmark.feedbackSections)) {
-            bookmark.feedbackSections.forEach(section => {
-              feedbacksMap[section.type] = section
-            })
-          }
-          
           return (
           <Card
             key={bookmark.id}
@@ -405,209 +217,45 @@ export default function UserPage() {
                   </Box>
                 )}
 
-                {/* 점수 (기존 코드 백업용 - 추후 제거 가능) */}
-                {(!bookmark.feedbackSections || bookmark.feedbackSections.length === 0) && bookmark.scores && (
-                  <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
-                    {bookmark.scores.pronunciation && (
-                      <Chip
-                        label={`발음 ${bookmark.scores.pronunciation}`}
-                        size="small"
-                        sx={{
-                          height: 24,
-                          fontSize: '0.75rem',
-                          fontWeight: 500,
-                          bgcolor: 'rgba(76,175,80,0.1)',
-                          color: '#4caf50',
-                          border: '1px solid rgba(76,175,80,0.2)'
-                        }}
-                      />
-                    )}
-                    {bookmark.scores.grammar && (
-                      <Chip
-                        label={`문법 ${bookmark.scores.grammar}`}
-                        size="small"
-                        sx={{
-                          height: 24,
-                          fontSize: '0.75rem',
-                          fontWeight: 500,
-                          bgcolor: 'rgba(33,150,243,0.1)',
-                          color: '#2196f3',
-                          color: '#2196f3',
-                          border: '1px solid rgba(33,150,243,0.2)'
-                        }}
-                      />
-                    )}
-                    {bookmark.scores.relevance && (
-                      <Chip
-                        label={`문맥 ${bookmark.scores.relevance}`}
-                        size="small"
-                        sx={{
-                          height: 24,
-                          fontSize: '0.75rem',
-                          fontWeight: 500,
-                          bgcolor: 'rgba(156,39,176,0.1)',
-                          color: '#9c27b0',
-                          border: '1px solid rgba(156,39,176,0.2)'
-                        }}
-                      />
-                    )}
-                  </Box>
-                )}
-
-                {/* 상세보기 버튼 */}
-                <Box 
-                  sx={{ 
-                    display: 'flex', 
-                    justifyContent: 'center', 
-                    alignItems: 'center',
-                    gap: 0.5,
-                    pt: 1,
-                    cursor: 'pointer',
-                    '&:hover': {
-                      '& .detail-text': {
-                        color: 'primary.main'
-                      },
-                      '& .detail-icon': {
-                        color: 'primary.main'
-                      }
-                    }
-                  }}
-                  onClick={() => handleToggleExpand(bookmark.bookmarkId)}
-                >
-                  <Typography 
-                    variant="body2" 
-                    className="detail-text"
-                    sx={{ 
-                      color: 'text.secondary',
-                      fontWeight: 500,
-                      transition: 'color 0.2s ease'
-                    }}
-                  >
-                    상세보기
-                  </Typography>
-                  {expandedCards[bookmark.bookmarkId] ? (
-                    <ExpandLessIcon className="detail-icon" sx={{ fontSize: 20, color: 'text.secondary', transition: 'color 0.2s ease' }} />
-                  ) : (
-                    <ExpandMoreIcon className="detail-icon" sx={{ fontSize: 20, color: 'text.secondary', transition: 'color 0.2s ease' }} />
-                  )}
-                </Box>
-
-                {/* 피드백 상세 (토글) */}
-                <Collapse in={expandedCards[bookmark.bookmarkId]}>
+                {/* 피드백 상세 (항상 표시) */}
+                {bookmark.feedbackSections && bookmark.feedbackSections.length > 0 && (
                   <Box sx={{ pt: 2 }}>
                     <Divider sx={{ mb: 2, borderColor: 'rgba(0,0,0,0.08)' }} />
                     <Stack spacing={2.5}>
                       {/* 피드백 섹션들 */}
-                      {bookmark.feedbackSections && bookmark.feedbackSections.length > 0 ? (
-                        bookmark.feedbackSections.map((section) => {
-                          const typeColors = {
-                            pronunciation: { bg: 'rgba(76,175,80,0.05)', border: 'rgba(76,175,80,0.15)' },
-                            grammar: { bg: 'rgba(33,150,243,0.05)', border: 'rgba(33,150,243,0.15)' },
-                            relevance: { bg: 'rgba(255,152,0,0.05)', border: 'rgba(255,152,0,0.15)' }
-                          }
-                          const colors = typeColors[section.type] || typeColors.pronunciation
-                          return (
-                            <Box key={section.type}>
-                              <Typography variant="subtitle2" fontWeight={600} color="text.primary" sx={{ mb: 1 }}>
-                                {feedbackTypeLabels[section.type] || section.type} 피드백
-                              </Typography>
-                              <Box
-                                sx={{
-                                  p: 1.5,
-                                  borderRadius: 2,
-                                  bgcolor: colors.bg,
-                                  border: `1px solid ${colors.border}`
-                                }}
-                              >
-                                <Typography variant="body2" sx={{ color: '#212121', lineHeight: 1.6, mb: 1 }}>
-                                  {section.feedbackKo || section.feedback_ko || ''}
-                                </Typography>
-                                <Typography variant="caption" sx={{ color: 'text.secondary', fontStyle: 'italic' }}>
-                                  {section.feedbackEn || section.feedback_en || ''}
-                                </Typography>
-                              </Box>
-                            </Box>
-                          )
-                        })
-                      ) : (
-                        // 기존 코드 (백업용 - 추후 제거 가능)
-                        <>
-                          {/* 발음 피드백 */}
-                          {feedbacksMap.pronunciation && (
-                            <Box>
-                              <Typography variant="subtitle2" fontWeight={600} color="text.primary" sx={{ mb: 1 }}>
-                                발음 피드백
-                              </Typography>
-                              <Box
-                                sx={{
-                                  p: 1.5,
-                                  borderRadius: 2,
-                                  bgcolor: 'rgba(76,175,80,0.05)',
-                                  border: '1px solid rgba(76,175,80,0.15)'
-                                }}
-                              >
-                                <Typography variant="body2" sx={{ color: '#212121', lineHeight: 1.6, mb: 1 }}>
-                                  {feedbacksMap.pronunciation.feedback_ko || feedbacksMap.pronunciation.feedbackKo}
-                                </Typography>
-                                <Typography variant="caption" sx={{ color: 'text.secondary', fontStyle: 'italic' }}>
-                                  {feedbacksMap.pronunciation.feedback_en || feedbacksMap.pronunciation.feedbackEn}
-                                </Typography>
-                              </Box>
-                            </Box>
-                          )}
-
-                          {/* 문법 피드백 */}
-                          {feedbacksMap.grammar && (
-                            <Box>
-                              <Typography variant="subtitle2" fontWeight={600} color="text.primary" sx={{ mb: 1 }}>
-                                문법 피드백
-                              </Typography>
-                              <Box
-                                sx={{
-                                  p: 1.5,
-                                  borderRadius: 2,
-                                  bgcolor: 'rgba(33,150,243,0.05)',
-                                  border: '1px solid rgba(33,150,243,0.15)'
-                                }}
-                              >
-                                <Typography variant="body2" sx={{ color: '#212121', lineHeight: 1.6, mb: 1 }}>
-                                  {feedbacksMap.grammar.feedback_ko || feedbacksMap.grammar.feedbackKo}
-                                </Typography>
-                                <Typography variant="caption" sx={{ color: 'text.secondary', fontStyle: 'italic' }}>
-                                  {feedbacksMap.grammar.feedback_en || feedbacksMap.grammar.feedbackEn}
-                                </Typography>
-                              </Box>
-                            </Box>
-                          )}
-                        </>
-                      )}
-
-                      {/* 관련성 피드백 (기존 코드 - 추후 제거 가능) */}
-                      {feedbacksMap.relevance && (
-                        <Box>
-                          <Typography variant="subtitle2" fontWeight={600} color="text.primary" sx={{ mb: 1 }}>
-                            문맥 피드백
-                          </Typography>
-                          <Box
-                            sx={{
-                              p: 1.5,
-                              borderRadius: 2,
-                              bgcolor: 'rgba(156,39,176,0.05)',
-                              border: '1px solid rgba(156,39,176,0.15)'
-                            }}
-                          >
-                            <Typography variant="body2" sx={{ color: '#212121', lineHeight: 1.6, mb: 1 }}>
-                              {feedbacksMap.relevance.feedback_ko || feedbacksMap.relevance.feedbackKo}
+                      {bookmark.feedbackSections.map((section) => {
+                        const typeColors = {
+                          pronunciation: { bg: 'rgba(76,175,80,0.05)', border: 'rgba(76,175,80,0.15)' },
+                          grammar: { bg: 'rgba(33,150,243,0.05)', border: 'rgba(33,150,243,0.15)' },
+                          relevance: { bg: 'rgba(255,152,0,0.05)', border: 'rgba(255,152,0,0.15)' }
+                        }
+                        const colors = typeColors[section.type] || typeColors.pronunciation
+                        return (
+                          <Box key={section.type}>
+                            <Typography variant="subtitle2" fontWeight={600} color="text.primary" sx={{ mb: 1 }}>
+                              {feedbackTypeLabels[section.type] || section.type} 피드백
                             </Typography>
-                            <Typography variant="caption" sx={{ color: 'text.secondary', fontStyle: 'italic' }}>
-                              {feedbacksMap.relevance.feedback_en || feedbacksMap.relevance.feedbackEn}
-                            </Typography>
+                            <Box
+                              sx={{
+                                p: 1.5,
+                                borderRadius: 2,
+                                bgcolor: colors.bg,
+                                border: `1px solid ${colors.border}`
+                              }}
+                            >
+                              <Typography variant="body2" sx={{ color: '#212121', lineHeight: 1.6, mb: 1 }}>
+                                {section.feedbackKo || section.feedback_ko || ''}
+                              </Typography>
+                              <Typography variant="caption" sx={{ color: 'text.secondary', fontStyle: 'italic' }}>
+                                {section.feedbackEn || section.feedback_en || ''}
+                              </Typography>
+                            </Box>
                           </Box>
-                        </Box>
-                      )}
+                        )
+                      })}
                     </Stack>
                   </Box>
-                </Collapse>
+                )}
               </Stack>
             </CardContent>
           </Card>

--- a/src/features/user/pages/UserPage.jsx
+++ b/src/features/user/pages/UserPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { 
   Typography, 
   Stack, 
@@ -8,11 +8,14 @@ import {
   Chip,
   IconButton,
   Collapse,
-  Divider
+  Divider,
+  CircularProgress,
+  Alert
 } from '@mui/material'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import ExpandLessIcon from '@mui/icons-material/ExpandLess'
 import BookmarkIcon from '@mui/icons-material/Bookmark'
+import useBookmarks from '../../../hooks/useBookmarks'
 
 // 더미 북마크 채팅 데이터 5개
 const MOCK_BOOKMARKED_CHATS = [
@@ -184,8 +187,14 @@ const MOCK_BOOKMARKED_CHATS = [
 ]
 
 export default function UserPage() {
+  const { bookmarks, loading, error, removeBookmark, refreshBookmarks } = useBookmarks()
   const [expandedCards, setExpandedCards] = useState({})
-  const [bookmarkedItems, setBookmarkedItems] = useState({})
+
+  // UserPage 마운트 시 북마크 목록 로드 (한 번만 실행)
+  useEffect(() => {
+    refreshBookmarks()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const handleToggleExpand = (bookmarkId) => {
     setExpandedCards(prev => ({
@@ -194,11 +203,17 @@ export default function UserPage() {
     }))
   }
 
-  const handleToggleBookmark = (bookmarkId) => {
-    setBookmarkedItems(prev => ({
-      ...prev,
-      [bookmarkId]: !prev[bookmarkId]
-    }))
+  const handleDeleteBookmark = async (bookmarkId) => {
+    if (window.confirm('북마크를 삭제하시겠습니까?')) {
+      await removeBookmark(bookmarkId)
+    }
+  }
+
+  // 피드백 타입별 라벨 매핑
+  const feedbackTypeLabels = {
+    pronunciation: '발음',
+    grammar: '문법',
+    relevance: '관련성'
   }
 
   return (
@@ -214,8 +229,34 @@ export default function UserPage() {
       </Stack>
 
       {/* 북마크 채팅 리스트 */}
+      {loading && (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+          <CircularProgress />
+        </Box>
+      )}
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
+      {!loading && !error && (!Array.isArray(bookmarks) || bookmarks.length === 0) && (
+        <Box sx={{ textAlign: 'center', py: 4 }}>
+          <Typography variant="body2" color="text.secondary">
+            북마크한 채팅이 없습니다.
+          </Typography>
+        </Box>
+      )}
       <Stack spacing={2.5}>
-        {MOCK_BOOKMARKED_CHATS.map((bookmark) => (
+        {Array.isArray(bookmarks) && bookmarks.map((bookmark) => {
+          // feedbackSections를 맵으로 변환 (type을 키로)
+          const feedbacksMap = {}
+          if (bookmark.feedbackSections && Array.isArray(bookmark.feedbackSections)) {
+            bookmark.feedbackSections.forEach(section => {
+              feedbacksMap[section.type] = section
+            })
+          }
+          
+          return (
           <Card
             key={bookmark.id}
             sx={{
@@ -249,16 +290,16 @@ export default function UserPage() {
             <CardContent sx={{ p: 3, position: 'relative' }}>
               {/* 북마크 아이콘 - 카드 오른쪽 위 */}
               <IconButton
-                onClick={() => handleToggleBookmark(bookmark.id)}
+                onClick={() => handleDeleteBookmark(bookmark.bookmarkId)}
                 size="small"
                 sx={{
                   position: 'absolute',
                   top: 16,
                   right: 16,
-                  color: bookmarkedItems[bookmark.id] ? '#FFA500' : 'rgba(0,0,0,0.4)',
+                  color: '#FFA500',
                   '&:hover': {
                     bgcolor: 'rgba(0,0,0,0.05)',
-                    color: bookmarkedItems[bookmark.id] ? '#FF8C00' : 'rgba(0,0,0,0.6)'
+                    color: '#FF8C00'
                   },
                   transition: 'color 0.2s ease',
                   zIndex: 1
@@ -296,7 +337,7 @@ export default function UserPage() {
                           lineHeight: 1.6
                         }}
                       >
-                        {bookmark.aiQuestion}
+                        {bookmark.aiQuestion || 'AI 질문 없음'}
                       </Typography>
                     </Box>
                   </Box>
@@ -329,13 +370,43 @@ export default function UserPage() {
                           lineHeight: 1.6
                         }}
                       >
-                        {bookmark.myAnswer}
+                        {bookmark.messageText}
                       </Typography>
                     </Box>
                   </Box>
 
                 {/* 점수 */}
-                {bookmark.scores && (
+                {bookmark.feedbackSections && bookmark.feedbackSections.length > 0 && (
+                  <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+                    {bookmark.feedbackSections.map((section) => {
+                      if (!section.score) return null
+                      const typeColors = {
+                        pronunciation: { bg: 'rgba(76,175,80,0.1)', color: '#4caf50', border: 'rgba(76,175,80,0.2)' },
+                        grammar: { bg: 'rgba(33,150,243,0.1)', color: '#2196f3', border: 'rgba(33,150,243,0.2)' },
+                        relevance: { bg: 'rgba(255,152,0,0.1)', color: '#ff9800', border: 'rgba(255,152,0,0.2)' }
+                      }
+                      const colors = typeColors[section.type] || typeColors.pronunciation
+                      return (
+                        <Chip
+                          key={section.type}
+                          label={`${feedbackTypeLabels[section.type] || section.type} ${section.score}`}
+                          size="small"
+                          sx={{
+                            height: 24,
+                            fontSize: '0.75rem',
+                            fontWeight: 500,
+                            bgcolor: colors.bg,
+                            color: colors.color,
+                            border: `1px solid ${colors.border}`
+                          }}
+                        />
+                      )
+                    })}
+                  </Box>
+                )}
+
+                {/* 점수 (기존 코드 백업용 - 추후 제거 가능) */}
+                {(!bookmark.feedbackSections || bookmark.feedbackSections.length === 0) && bookmark.scores && (
                   <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
                     {bookmark.scores.pronunciation && (
                       <Chip
@@ -360,6 +431,7 @@ export default function UserPage() {
                           fontSize: '0.75rem',
                           fontWeight: 500,
                           bgcolor: 'rgba(33,150,243,0.1)',
+                          color: '#2196f3',
                           color: '#2196f3',
                           border: '1px solid rgba(33,150,243,0.2)'
                         }}
@@ -400,7 +472,7 @@ export default function UserPage() {
                       }
                     }
                   }}
-                  onClick={() => handleToggleExpand(bookmark.id)}
+                  onClick={() => handleToggleExpand(bookmark.bookmarkId)}
                 >
                   <Typography 
                     variant="body2" 
@@ -413,7 +485,7 @@ export default function UserPage() {
                   >
                     상세보기
                   </Typography>
-                  {expandedCards[bookmark.id] ? (
+                  {expandedCards[bookmark.bookmarkId] ? (
                     <ExpandLessIcon className="detail-icon" sx={{ fontSize: 20, color: 'text.secondary', transition: 'color 0.2s ease' }} />
                   ) : (
                     <ExpandMoreIcon className="detail-icon" sx={{ fontSize: 20, color: 'text.secondary', transition: 'color 0.2s ease' }} />
@@ -421,60 +493,97 @@ export default function UserPage() {
                 </Box>
 
                 {/* 피드백 상세 (토글) */}
-                <Collapse in={expandedCards[bookmark.id]}>
+                <Collapse in={expandedCards[bookmark.bookmarkId]}>
                   <Box sx={{ pt: 2 }}>
                     <Divider sx={{ mb: 2, borderColor: 'rgba(0,0,0,0.08)' }} />
                     <Stack spacing={2.5}>
-                      {/* 발음 피드백 */}
-                      {bookmark.feedbacks?.pronunciation && (
-                        <Box>
-                          <Typography variant="subtitle2" fontWeight={600} color="text.primary" sx={{ mb: 1 }}>
-                            발음 피드백
-                          </Typography>
-                          <Box
-                            sx={{
-                              p: 1.5,
-                              borderRadius: 2,
-                              bgcolor: 'rgba(76,175,80,0.05)',
-                              border: '1px solid rgba(76,175,80,0.15)'
-                            }}
-                          >
-                            <Typography variant="body2" sx={{ color: '#212121', lineHeight: 1.6, mb: 1 }}>
-                              {bookmark.feedbacks.pronunciation.feedback_ko}
-                            </Typography>
-                            <Typography variant="caption" sx={{ color: 'text.secondary', fontStyle: 'italic' }}>
-                              {bookmark.feedbacks.pronunciation.feedback_en}
-                            </Typography>
-                          </Box>
-                        </Box>
+                      {/* 피드백 섹션들 */}
+                      {bookmark.feedbackSections && bookmark.feedbackSections.length > 0 ? (
+                        bookmark.feedbackSections.map((section) => {
+                          const typeColors = {
+                            pronunciation: { bg: 'rgba(76,175,80,0.05)', border: 'rgba(76,175,80,0.15)' },
+                            grammar: { bg: 'rgba(33,150,243,0.05)', border: 'rgba(33,150,243,0.15)' },
+                            relevance: { bg: 'rgba(255,152,0,0.05)', border: 'rgba(255,152,0,0.15)' }
+                          }
+                          const colors = typeColors[section.type] || typeColors.pronunciation
+                          return (
+                            <Box key={section.type}>
+                              <Typography variant="subtitle2" fontWeight={600} color="text.primary" sx={{ mb: 1 }}>
+                                {feedbackTypeLabels[section.type] || section.type} 피드백
+                              </Typography>
+                              <Box
+                                sx={{
+                                  p: 1.5,
+                                  borderRadius: 2,
+                                  bgcolor: colors.bg,
+                                  border: `1px solid ${colors.border}`
+                                }}
+                              >
+                                <Typography variant="body2" sx={{ color: '#212121', lineHeight: 1.6, mb: 1 }}>
+                                  {section.feedbackKo || section.feedback_ko || ''}
+                                </Typography>
+                                <Typography variant="caption" sx={{ color: 'text.secondary', fontStyle: 'italic' }}>
+                                  {section.feedbackEn || section.feedback_en || ''}
+                                </Typography>
+                              </Box>
+                            </Box>
+                          )
+                        })
+                      ) : (
+                        // 기존 코드 (백업용 - 추후 제거 가능)
+                        <>
+                          {/* 발음 피드백 */}
+                          {feedbacksMap.pronunciation && (
+                            <Box>
+                              <Typography variant="subtitle2" fontWeight={600} color="text.primary" sx={{ mb: 1 }}>
+                                발음 피드백
+                              </Typography>
+                              <Box
+                                sx={{
+                                  p: 1.5,
+                                  borderRadius: 2,
+                                  bgcolor: 'rgba(76,175,80,0.05)',
+                                  border: '1px solid rgba(76,175,80,0.15)'
+                                }}
+                              >
+                                <Typography variant="body2" sx={{ color: '#212121', lineHeight: 1.6, mb: 1 }}>
+                                  {feedbacksMap.pronunciation.feedback_ko || feedbacksMap.pronunciation.feedbackKo}
+                                </Typography>
+                                <Typography variant="caption" sx={{ color: 'text.secondary', fontStyle: 'italic' }}>
+                                  {feedbacksMap.pronunciation.feedback_en || feedbacksMap.pronunciation.feedbackEn}
+                                </Typography>
+                              </Box>
+                            </Box>
+                          )}
+
+                          {/* 문법 피드백 */}
+                          {feedbacksMap.grammar && (
+                            <Box>
+                              <Typography variant="subtitle2" fontWeight={600} color="text.primary" sx={{ mb: 1 }}>
+                                문법 피드백
+                              </Typography>
+                              <Box
+                                sx={{
+                                  p: 1.5,
+                                  borderRadius: 2,
+                                  bgcolor: 'rgba(33,150,243,0.05)',
+                                  border: '1px solid rgba(33,150,243,0.15)'
+                                }}
+                              >
+                                <Typography variant="body2" sx={{ color: '#212121', lineHeight: 1.6, mb: 1 }}>
+                                  {feedbacksMap.grammar.feedback_ko || feedbacksMap.grammar.feedbackKo}
+                                </Typography>
+                                <Typography variant="caption" sx={{ color: 'text.secondary', fontStyle: 'italic' }}>
+                                  {feedbacksMap.grammar.feedback_en || feedbacksMap.grammar.feedbackEn}
+                                </Typography>
+                              </Box>
+                            </Box>
+                          )}
+                        </>
                       )}
 
-                      {/* 문법 피드백 */}
-                      {bookmark.feedbacks?.grammar && (
-                        <Box>
-                          <Typography variant="subtitle2" fontWeight={600} color="text.primary" sx={{ mb: 1 }}>
-                            문법 피드백
-                          </Typography>
-                          <Box
-                            sx={{
-                              p: 1.5,
-                              borderRadius: 2,
-                              bgcolor: 'rgba(33,150,243,0.05)',
-                              border: '1px solid rgba(33,150,243,0.15)'
-                            }}
-                          >
-                            <Typography variant="body2" sx={{ color: '#212121', lineHeight: 1.6, mb: 1 }}>
-                              {bookmark.feedbacks.grammar.feedback_ko}
-                            </Typography>
-                            <Typography variant="caption" sx={{ color: 'text.secondary', fontStyle: 'italic' }}>
-                              {bookmark.feedbacks.grammar.feedback_en}
-                            </Typography>
-                          </Box>
-                        </Box>
-                      )}
-
-                      {/* 관련성 피드백 */}
-                      {bookmark.feedbacks?.relevance && (
+                      {/* 관련성 피드백 (기존 코드 - 추후 제거 가능) */}
+                      {feedbacksMap.relevance && (
                         <Box>
                           <Typography variant="subtitle2" fontWeight={600} color="text.primary" sx={{ mb: 1 }}>
                             문맥 피드백
@@ -488,10 +597,10 @@ export default function UserPage() {
                             }}
                           >
                             <Typography variant="body2" sx={{ color: '#212121', lineHeight: 1.6, mb: 1 }}>
-                              {bookmark.feedbacks.relevance.feedback_ko}
+                              {feedbacksMap.relevance.feedback_ko || feedbacksMap.relevance.feedbackKo}
                             </Typography>
                             <Typography variant="caption" sx={{ color: 'text.secondary', fontStyle: 'italic' }}>
-                              {bookmark.feedbacks.relevance.feedback_en}
+                              {feedbacksMap.relevance.feedback_en || feedbacksMap.relevance.feedbackEn}
                             </Typography>
                           </Box>
                         </Box>
@@ -502,7 +611,8 @@ export default function UserPage() {
               </Stack>
             </CardContent>
           </Card>
-        ))}
+        )
+        })}
       </Stack>
     </Stack>
   )

--- a/src/hooks/useBookmarks.js
+++ b/src/hooks/useBookmarks.js
@@ -30,7 +30,17 @@ export default function useBookmarks() {
     setError(null)
     try {
       const data = await getMyBookmarks()
-      setBookmarks(data)
+      // 응답이 배열인지 확인하고, 배열이 아니면 빈 배열로 설정
+      // 만약 응답이 객체로 감싸져 있다면 (예: { bookmarks: [...] }), 적절히 추출
+      let bookmarksArray = []
+      if (Array.isArray(data)) {
+        bookmarksArray = data
+      } else if (data && Array.isArray(data.data)) {
+        bookmarksArray = data.data
+      } else if (data && Array.isArray(data.bookmarks)) {
+        bookmarksArray = data.bookmarks
+      }
+      setBookmarks(bookmarksArray)
     } catch (err) {
       console.error('Failed to fetch bookmarks:', err)
       setError(err.message || '북마크를 불러오는데 실패했습니다.')
@@ -73,10 +83,11 @@ export default function useBookmarks() {
     }
   }, [refreshBookmarks])
 
-  // 컴포넌트 마운트 시 북마크 목록 로드
-  useEffect(() => {
-    refreshBookmarks()
-  }, [refreshBookmarks])
+  // 컴포넌트 마운트 시 북마크 목록 로드 (자동 로드 비활성화)
+  // 필요 시 수동으로 refreshBookmarks() 호출
+  // useEffect(() => {
+  //   refreshBookmarks()
+  // }, [refreshBookmarks])
 
   return {
     bookmarks,

--- a/src/services/bookmarkService.js
+++ b/src/services/bookmarkService.js
@@ -12,8 +12,9 @@
  */
 
 import { request } from './httpClient'
+import { API_ENDPOINTS } from '../config/constants'
 
-const BASE_URL = '/internal/bookmarks'
+const BASE_URL = `${API_ENDPOINTS.GATEWAY}/bookmarks`
 
 /**
  * 내 북마크 목록 조회

--- a/src/services/roleplayService.js
+++ b/src/services/roleplayService.js
@@ -117,6 +117,25 @@ export async function getSessionUtterances(sessionId) {
 }
 
 /**
+ * 완료된 세션 목록 조회
+ * @returns {Promise<Array>} 완료된 세션 목록
+ *   [
+ *     {
+ *       sessionId: string,
+ *       scenarioTitle: string,
+ *       myRole: string,
+ *       aiRole: string,
+ *       executedDate: string (ISO date string)
+ *     },
+ *     ...
+ *   ]
+ */
+export async function getCompletedSessions() {
+  const url = `${API_ENDPOINTS.GATEWAY}/roleplaying/sessions/completed`
+  return httpClient.get(url)
+}
+
+/**
  * WebSocket 연결 생성
  * @param {string} wsUrl - WebSocket URL
  * @param {Function} onMessage - 메시지 수신 핸들러


### PR DESCRIPTION
## 🧩 개요
롤플레잉 종료 이후 피드백 조회 흐름을 개선하고,
완료된 세션 목록 기반 피드백 접근, 피드백 시각화 강화,
북마크/세션/피드백 상태 관리 안정화를 포함한 UI·로직 전반을 정리했습니다.

## 🔗 관련 이슈
Closes #

## 🌿 브랜치 정보
- 브랜치 이름: `feature/<이슈번호>-<작업내용>` 또는 `fix/<이슈번호>-<수정내용>`
- 기준 브랜치: `develop`

> 브랜치 이름 규칙이 맞지 않으면 리뷰 요청 전에 수정해주세요.

## ✅ 변경 사항
- [ ] 완료된 세션 목록 기반 피드백 페이지 UI 구현
- [ ] 완료된 세션 목록 조회 API 연동 (getCompletedSessions)
- [ ] 세션 선택 시 발화 목록 로드 및 SummaryView 연결
- [ ] 롤플레잉 종료 시 피드백 이동 여부 확인 모달 추가
- [ ] 세션 종료 콜백(onSessionEnded) 구조 도입
- [ ] 피드백 메시지 표시 방식 개선 (섹션 단위 시각화)
- [ ] 발화 메시지에 피드백 섹션(발음/문법/관련성) 렌더링 추가
- [ ] 피드백 섹션 정렬 기준 개선 (grammar → pronunciation → relevance)
- [ ] AI 질문/번역/추천 키워드 표시 로직 확장
- [ ] MessageBubble 렌더링 최적화 (memo + 비교 조건 강화)
- [ ] 북마크 목록/상세 UI 단순화 및 피드백 항상 표시 구조로 변경
- [ ] 북마크 데이터 응답 구조 유연화 처리 (배열/객체 대응)
- [ ] 북마크 API Gateway 경로 기준으로 통합
- [ ] 시나리오/슬랙 연동 로딩 및 에러 처리 로직 정리
- [ ] Roleplay 세션 view 전환 조건 완화 및 UX 개선

## 🧪 테스트
이 변경을 어떻게 검증했나요?

## 📸 참고 자료
(선택) 스크린샷, 로그 등

---

> 💡 **PR 생성 시 “Closes #이슈번호”를 포함하면**  
> 병합 시 해당 이슈가 자동으로 닫힙니다.
