### PR TITLE
feat: 평가 중 UI 개선 및 재시도 TTS 연동

### DIFF
--- a/src/components/Common/LoadingSpinner.jsx
+++ b/src/components/Common/LoadingSpinner.jsx
@@ -54,3 +54,4 @@ export default function LoadingSpinner({ message = '로딩 중...' }) {
 
 
 
+

--- a/src/features/roleplay/pages/RoleplayPage.jsx
+++ b/src/features/roleplay/pages/RoleplayPage.jsx
@@ -227,6 +227,7 @@ export default function RoleplayPage() {
           onKeyboardToggle={session.toggleKeyboardMode}
           textInput={session.textInput}
           onTextInputChange={session.handleTextInputChange}
+          isEvaluating={session.evaluating}
           onSendMessage={session.sendMessage}
           isTTSPlaying={session.isTTSPlaying}
           onAvatarLoad={session.handleAvatarLoad}

--- a/src/features/roleplay/pages/RoleplayPage.jsx
+++ b/src/features/roleplay/pages/RoleplayPage.jsx
@@ -250,8 +250,8 @@ export default function RoleplayPage() {
     )
   }
 
-  // 분석 중 화면
-  if (session.evaluating) {
+  // 분석 중 화면 (세션 중이 아닐 때만 전체 화면 표시)
+  if (session.evaluating && session.view !== 'session') {
     return (
       <Box
         sx={{

--- a/src/features/roleplay/session/components/MicButton.jsx
+++ b/src/features/roleplay/session/components/MicButton.jsx
@@ -9,7 +9,8 @@ export default function MicButton({
   onKeyboardToggle,
   isKeyboardMode = false,
   showModeToggle = true, // 모드 전환 버튼 표시 여부
-  isTTSPlaying = false // TTS 재생 중 여부
+  isTTSPlaying = false, // TTS 재생 중 여부
+  isEvaluating = false // 평가 중 여부
 }) {
   return (
     <Box 
@@ -48,8 +49,25 @@ export default function MicButton({
             녹음 중
           </Typography>
         )}
+        {/* 평가 중 텍스트 - 버튼 위쪽에 고정 */}
+        {isEvaluating && !isRecording && !isTTSPlaying && (
+          <Typography 
+            variant="caption" 
+            sx={{ 
+              position: 'absolute',
+              bottom: '100%',
+              mb: 0.75,
+              fontWeight: 600,
+              fontSize: '0.75rem',
+              color: 'rgba(124, 108, 255, 0.85)',
+              whiteSpace: 'nowrap'
+            }}
+          >
+            평가하는 중
+          </Typography>
+        )}
         {/* TTS 재생 중 텍스트 - 버튼 위쪽에 고정 */}
-        {isTTSPlaying && !isRecording && (
+        {isTTSPlaying && !isRecording && !isEvaluating && (
           <Typography 
             variant="caption" 
             sx={{ 

--- a/src/features/roleplay/session/components/MicButton.jsx
+++ b/src/features/roleplay/session/components/MicButton.jsx
@@ -87,24 +87,24 @@ export default function MicButton({
         <IconButton
           color="primary"
           onClick={onClick}
-          disabled={isTTSPlaying}
+          disabled={isTTSPlaying || isEvaluating}
           sx={{
             width: 64,
             height: 64,
             border: isRecording ? 'none' : '1px solid rgba(0,0,0,0.2)',
             background: isRecording 
               ? 'linear-gradient(135deg, #FF6B6B 0%, #FF5252 100%)' 
-              : isTTSPlaying 
+              : (isTTSPlaying || isEvaluating) 
                 ? '#f5f5f5' 
                 : '#FFFFFF',
-            color: isRecording ? '#FFFFFF' : isTTSPlaying ? '#9e9e9e' : '#212121',
+            color: isRecording ? '#FFFFFF' : (isTTSPlaying || isEvaluating) ? '#9e9e9e' : '#212121',
             borderRadius: '50%',
             boxShadow: 'none',
             transition: 'transform 0.15s ease',
             '&:hover': { 
               background: isRecording 
                 ? 'linear-gradient(135deg, #FF7B7B 0%, #FF6262 100%)' 
-                : isTTSPlaying
+                : (isTTSPlaying || isEvaluating)
                   ? '#f5f5f5'
                   : '#f5f5f5',
               borderColor: isRecording ? 'none' : 'rgba(0,0,0,0.3)'

--- a/src/features/roleplay/session/components/SessionView.jsx
+++ b/src/features/roleplay/session/components/SessionView.jsx
@@ -58,6 +58,7 @@ export default function SessionView({
           isKeyboardMode={isKeyboardMode}
           showModeToggle={initialInputMode !== 'text'} // 초기 모드가 텍스트가 아니면 전환 버튼 표시
           isTTSPlaying={isTTSPlaying}
+          isEvaluating={isEvaluating}
         />
       ) : (
         <MicButton 

--- a/src/features/roleplay/session/components/SessionView.jsx
+++ b/src/features/roleplay/session/components/SessionView.jsx
@@ -24,7 +24,8 @@ export default function SessionView({
   audioRef = null,
   onFetchKeywords = () => {},
   aiRole = 'AI', // AI 역할 (기본값: 'AI')
-  initialInputMode = null // 초기 입력 모드 ('text' | 'voice' | null)
+  initialInputMode = null, // 초기 입력 모드 ('text' | 'voice' | null)
+  isEvaluating = false // 평가 중 여부
 }) {
   return (
     <Box
@@ -66,6 +67,7 @@ export default function SessionView({
           isKeyboardMode={isKeyboardMode}
           showModeToggle={initialInputMode !== 'voice'} // 초기 모드가 음성이 아니면 전환 버튼 표시
           isTTSPlaying={isTTSPlaying}
+          isEvaluating={isEvaluating}
         />
       )}
     </Box>

--- a/src/features/roleplay/session/components/TextInputArea.jsx
+++ b/src/features/roleplay/session/components/TextInputArea.jsx
@@ -12,19 +12,20 @@ export default function TextInputArea({
   isKeyboardMode = true,
   placeholder = "답변을 입력하세요...",
   showModeToggle = true, // 모드 전환 버튼 표시 여부
-  isTTSPlaying = false // TTS 재생 중 여부
+  isTTSPlaying = false, // TTS 재생 중 여부
+  isEvaluating = false // 평가 중 여부
 }) {
   const handleKeyPress = (e) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault()
-      if (value.trim() && !isTTSPlaying) {
+      if (value.trim() && !isTTSPlaying && !isEvaluating) {
         onSend()
       }
     }
   }
 
   const handleSend = () => {
-    if (value.trim() && !isTTSPlaying) {
+    if (value.trim() && !isTTSPlaying && !isEvaluating) {
       onSend()
     }
   }
@@ -55,32 +56,32 @@ export default function TextInputArea({
           value={value}
           onChange={onChange}
           onKeyPress={handleKeyPress}
-          placeholder={isTTSPlaying ? 'AI가 말하는 중...' : placeholder}
+          placeholder={isTTSPlaying ? 'AI가 말하는 중...' : isEvaluating ? '평가하는 중...' : placeholder}
           variant="outlined"
           size="small"
-          disabled={isTTSPlaying}
+          disabled={isTTSPlaying || isEvaluating}
           sx={{
             '& .MuiOutlinedInput-root': {
-              backgroundColor: isTTSPlaying ? '#f5f5f5' : '#ffffff',
+              backgroundColor: (isTTSPlaying || isEvaluating) ? '#f5f5f5' : '#ffffff',
               borderRadius: 1,
-              color: isTTSPlaying ? '#9e9e9e' : '#212121',
+              color: (isTTSPlaying || isEvaluating) ? '#9e9e9e' : '#212121',
               '& fieldset': {
-                borderColor: isTTSPlaying ? 'rgba(0,0,0,0.12)' : 'rgba(0,0,0,0.23)'
+                borderColor: (isTTSPlaying || isEvaluating) ? 'rgba(0,0,0,0.12)' : 'rgba(0,0,0,0.23)'
               },
               '&:hover fieldset': {
-                borderColor: isTTSPlaying ? 'rgba(0,0,0,0.12)' : 'rgba(0,0,0,0.4)'
+                borderColor: (isTTSPlaying || isEvaluating) ? 'rgba(0,0,0,0.12)' : 'rgba(0,0,0,0.4)'
               },
               '&.Mui-focused fieldset': {
-                borderColor: isTTSPlaying ? 'rgba(0,0,0,0.12)' : '#6C63FF'
+                borderColor: (isTTSPlaying || isEvaluating) ? 'rgba(0,0,0,0.12)' : '#6C63FF'
               },
               '&.Mui-disabled': {
                 backgroundColor: '#f5f5f5'
               }
             },
             '& .MuiInputBase-input': {
-              color: isTTSPlaying ? '#9e9e9e' : '#212121',
+              color: (isTTSPlaying || isEvaluating) ? '#9e9e9e' : '#212121',
               '&::placeholder': {
-                color: isTTSPlaying ? 'rgba(108, 99, 255, 0.6)' : 'rgba(245,246,255,0.5)',
+                color: (isTTSPlaying || isEvaluating) ? 'rgba(108, 99, 255, 0.6)' : 'rgba(245,246,255,0.5)',
                 opacity: 1
               }
             }
@@ -89,11 +90,12 @@ export default function TextInputArea({
         {showModeToggle && (
           <IconButton
             onClick={onMicToggle}
+            disabled={isEvaluating}
             sx={{
               width: 40,
               height: 40,
               backgroundColor: '#ffffff',
-              color: '#212121',
+              color: isEvaluating ? '#9e9e9e' : '#212121',
               border: '1px solid rgba(0,0,0,0.2)',
               '&:hover': {
                 backgroundColor: '#f5f5f5'
@@ -106,14 +108,14 @@ export default function TextInputArea({
         )}
         <IconButton
           onClick={handleSend}
-          disabled={!value.trim() || isTTSPlaying}
+          disabled={!value.trim() || isTTSPlaying || isEvaluating}
           sx={{
             width: 40,
             height: 40,
-            backgroundColor: (value.trim() && !isTTSPlaying) ? '#6C63FF' : '#e0e0e0',
-            color: (value.trim() && !isTTSPlaying) ? '#ffffff' : '#9e9e9e',
+            backgroundColor: (value.trim() && !isTTSPlaying && !isEvaluating) ? '#6C63FF' : '#e0e0e0',
+            color: (value.trim() && !isTTSPlaying && !isEvaluating) ? '#ffffff' : '#9e9e9e',
             '&:hover': {
-              backgroundColor: (value.trim() && !isTTSPlaying) ? '#5B4DFF' : '#d5d5d5'
+              backgroundColor: (value.trim() && !isTTSPlaying && !isEvaluating) ? '#5B4DFF' : '#d5d5d5'
             },
             '&.Mui-disabled': {
               backgroundColor: '#e0e0e0',

--- a/src/features/roleplay/session/hooks/useRoleplaySession.js
+++ b/src/features/roleplay/session/hooks/useRoleplaySession.js
@@ -478,12 +478,12 @@ export default function useRoleplaySession(options = {}) {
     const isFixedQuestion = message.is_fixed_question || false
     const recommendedKeywords = message.recommended_keywords || message.recommendedKeywords || null
     
-    // 재질문인지 확인: 바로 이전 메시지가 피드백 메시지인지 확인
-    const isRetryQuestion = messages.length > 0 && 
+    // 재질문인지 확인: 백엔드 플래그 우선, 없으면 이전 메시지 내용으로 판단 (fallback)
+    const isRetryQuestion = message.is_retry_question || (messages.length > 0 && 
       messages[messages.length - 1].who === 'AI' && 
       messages[messages.length - 1].feedbackSections && 
       Array.isArray(messages[messages.length - 1].feedbackSections) && 
-      messages[messages.length - 1].feedbackSections.length > 0
+      messages[messages.length - 1].feedbackSections.length > 0)
     
     if (!isAvatarLoaded && messages.length === 0) {
       pendingFirstMessageRef.current = {
@@ -1326,7 +1326,7 @@ export default function useRoleplaySession(options = {}) {
         
         scriptProcessor.onaudioprocess = (event) => {
           const currentWs = wsConnection
-          if (!currentWs || currentWs.readyState !== WebSocket.OPEN || !isInitialized) {
+          if (!currentWs || currentWs.readyState !== WebSocket.OPEN || !isInitialized || !isRecordingRef.current) {
             return
           }
           

--- a/src/features/roleplay/session/hooks/useRoleplaySession.js
+++ b/src/features/roleplay/session/hooks/useRoleplaySession.js
@@ -116,6 +116,7 @@ export default function useRoleplaySession(options = {}) {
   const lipSyncDelayTimeoutRef = useRef(null)
   const lipSyncEndTimeoutRef = useRef(null)
   const isFirstTTSAudioRef = useRef(true) // 첫 TTS 오디오인지 추적
+  const retryTTSDelayTimeoutRef = useRef(null) // 재질문 TTS 지연 재생용
 
   // ========================================
   // 유틸리티 함수
@@ -162,7 +163,7 @@ export default function useRoleplaySession(options = {}) {
    * 타이핑 효과 후 TTS 재생까지 처리
    * 첫 질문(isFixedQuestion=true)인 경우 타이핑 효과 없이 즉시 표시하고 TTS 재생
    */
-  const addAIMessage = (text, translation, isFixedQuestion = false, isStreaming = false, recommendedKeywords = null) => {
+  const addAIMessage = (text, translation, isFixedQuestion = false, isStreaming = false, recommendedKeywords = null, isRetryQuestion = false) => {
     let skipTyping = false
     
     setMessages(prev => {
@@ -176,7 +177,8 @@ export default function useRoleplaySession(options = {}) {
         isFixedQuestion,
         isStreaming,
         skipTyping, // 타이핑 효과 스킵 플래그
-        recommendedKeywords // 추천 키워드 (scenario_message 테이블에서 가져옴)
+        recommendedKeywords, // 추천 키워드 (scenario_message 테이블에서 가져옴)
+        isRetryQuestion // 재질문 플래그
       }]
     })
 
@@ -344,13 +346,44 @@ export default function useRoleplaySession(options = {}) {
         })
       }
       
-      // 첫 TTS 오디오인 경우 2초 딜레이, 아니면 즉시 재생
-      if (isFirstTTSAudioRef.current) {
+      // 재질문인지 확인: 마지막 메시지가 재질문인지 확인
+      const lastMessage = messages[messages.length - 1]
+      const isRetryQuestion = lastMessage && lastMessage.isRetryQuestion
+      
+      if (isRetryQuestion) {
+        // 재질문인 경우: 피드백 표시 완료 + 재질문 텍스트 타이핑 완료 후 TTS 재생
+        // 피드백 메시지 찾기
+        const feedbackMessage = [...messages].reverse().find(msg => 
+          msg.who === 'AI' && 
+          msg.feedbackSections && 
+          Array.isArray(msg.feedbackSections) && 
+          msg.feedbackSections.length > 0
+        )
+        
+        // 피드백 섹션 표시 시간 계산 (각 섹션이 순서대로 표시되는 시간)
+        const SECTION_DISPLAY_DELAY = 300 // 각 섹션 표시 간격 (ms)
+        const feedbackDisplayDuration = feedbackMessage ? feedbackMessage.feedbackSections.length * SECTION_DISPLAY_DELAY : 0
+        
+        // 재질문 텍스트의 타이핑 시간 계산
+        const retryText = lastMessage.text || ''
+        const retryTypingDuration = retryText.length * TYPING_SPEED_MS_PER_CHAR + TYPING_DELAY_MS
+        
+        // 총 대기 시간: 피드백 표시 + 재질문 타이핑 + 여유 시간
+        const totalWaitTime = feedbackDisplayDuration + retryTypingDuration + 500
+        
+        // 지연 후 TTS 재생
+        clearTimeoutRef(retryTTSDelayTimeoutRef)
+        retryTTSDelayTimeoutRef.current = setTimeout(() => {
+          playAudio()
+        }, totalWaitTime)
+      } else if (isFirstTTSAudioRef.current) {
+        // 첫 TTS 오디오인 경우 2초 딜레이
         isFirstTTSAudioRef.current = false // 다음부터는 즉시 재생
         setTimeout(() => {
           playAudio()
         }, 2000) // 2초 딜레이
       } else {
+        // 일반 메시지는 즉시 재생
         playAudio()
       }
     } catch (error) {
@@ -438,9 +471,19 @@ export default function useRoleplaySession(options = {}) {
    * AI_TEXT 메시지 처리
    */
   const handleAIText = (message) => {
+    // AI 응답이 도착하면 평가 중 상태 해제
+    setEvaluating(false)
+    
     const translationText = extractTranslation(message)
     const isFixedQuestion = message.is_fixed_question || false
     const recommendedKeywords = message.recommended_keywords || message.recommendedKeywords || null
+    
+    // 재질문인지 확인: 바로 이전 메시지가 피드백 메시지인지 확인
+    const isRetryQuestion = messages.length > 0 && 
+      messages[messages.length - 1].who === 'AI' && 
+      messages[messages.length - 1].feedbackSections && 
+      Array.isArray(messages[messages.length - 1].feedbackSections) && 
+      messages[messages.length - 1].feedbackSections.length > 0
     
     if (!isAvatarLoaded && messages.length === 0) {
       pendingFirstMessageRef.current = {
@@ -477,13 +520,17 @@ export default function useRoleplaySession(options = {}) {
       return
     }
     
-    addAIMessage(message.text, translationText, isFixedQuestion, false, recommendedKeywords)
+    // 재질문인 경우 플래그 추가
+    addAIMessage(message.text, translationText, isFixedQuestion, false, recommendedKeywords, isRetryQuestion)
   }
 
   /**
    * AI_TEXT_STREAMING 메시지 처리
    */
   const handleAIStreaming = (message) => {
+    // AI 응답 스트리밍이 시작되면 평가 중 상태 해제
+    setEvaluating(false)
+    
     const streamingTranslation = extractTranslation(message)
     
     clearTimeoutRef(aiTypingTimeoutRef)
@@ -720,6 +767,9 @@ export default function useRoleplaySession(options = {}) {
    * RETRY_REQUIRED 메시지 처리
    */
   const handleRetryRequired = () => {
+    // 재시도 요청이 도착하면 평가 중 상태 해제 (피드백이 표시되므로)
+    setEvaluating(false)
+    
     needsCorrectionRef.current = true
     
     if (pendingFeedbackSectionsRef.current.length > 0) {
@@ -734,6 +784,9 @@ export default function useRoleplaySession(options = {}) {
    * 각 피드백 섹션이 생성될 때마다 즉시 화면에 표시하여 사용자 대기 시간 감소
    */
   const handleFeedbackSections = (message) => {
+    // 피드백이 도착하면 평가 중 상태 해제
+    setEvaluating(false)
+    
     storeFeedbackSections(message.sections)
     
     // 현재까지 모인 모든 피드백 섹션 가져오기 (정렬 포함)
@@ -807,6 +860,9 @@ export default function useRoleplaySession(options = {}) {
    * ERROR 메시지 처리
    */
   const handleError = (message) => {
+    // 에러 발생 시 평가 중 상태 해제
+    setEvaluating(false)
+    
     if (message.code === 'SILENCE_DETECTED') {
       console.info('음성이 감지되지 않았습니다. 다시 말씀해주세요.')
       setMessages(prev => {
@@ -1201,6 +1257,8 @@ export default function useRoleplaySession(options = {}) {
       text: userText
     }
     wsConnection.send(JSON.stringify(userMessage))
+    // 사용자 텍스트 전송 후 평가 중 상태로 설정
+    setEvaluating(true)
   }
 
   // ========================================
@@ -1382,6 +1440,8 @@ export default function useRoleplaySession(options = {}) {
           type: 'UTTERANCE_END'
         }
         wsConnection.send(JSON.stringify(utteranceEndMessage))
+        // UTTERANCE_END 메시지 전송 후 평가 중 상태로 설정
+        setEvaluating(true)
       } catch (error) {
         // UTTERANCE_END 메시지 전송 실패 무시
       }


### PR DESCRIPTION
## 📝 작업 내용
사용자 경험 개선을 위해 롤플레이 세션 중 평가 단계의 UI와 로직을 수정했습니다.

- **평가 중 입력 제한**: 사용자가 답변을 보낸 후 AI의 피드백이 올 때까지 마이크 버튼과 텍스트 입력창을 비활성화하여 중복 입력을 방지했습니다.
- **인라인 로딩 표시**: 기존에 전체 화면을 가리던 '분석 중' 로딩 화면을 제거했습니다. 대신 세션 화면을 유지하면서 마이크 버튼 상단에 '평가하는 중...' 메시지를 표시하여 대화의 흐름이 끊기지 않도록 개선했습니다.
- **재시도 플래그 대응**: 백엔드에서 전달하는 `is_retry_question` 플래그를 인식하여, 재질문 시 피드백 확인 후 적절한 타이밍에 TTS가 재생되도록 수정했습니다.

## 🔗 관련 이슈
- 관련 기능: 실시간 평가 UI 피드백